### PR TITLE
Fix license information

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,11 @@
+Copyright 2017 API Changelog Ltd.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at [apache.org/licenses/LICENSE-2.0](http://www.apache.org/licenses/LICENSE-2.0)
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
       "email": "bpedro@hitchhq.com"
     }
   ],
-  "license": "MIT",
+  "license": "Apache-2.0",
   "bugs": {
     "url": "https://github.com/fmvilas/asyncapi/issues"
   },

--- a/package.json
+++ b/package.json
@@ -10,7 +10,16 @@
     "type": "git",
     "url": "git+https://github.com/fmvilas/asyncapi.git"
   },
-  "author": "Francisco Mendez Vilas (fmvilas@gmail.com)",
+  "author": {
+    "name": "Francisco Mendez Vilas",
+    "email": "fmvilas@gmail.com"
+  },
+  "contributors": [
+    {
+      "name": "Bruno Pedro",
+      "email": "bpedro@hitchhq.com"
+    }
+  ],
   "license": "MIT",
   "bugs": {
     "url": "https://github.com/fmvilas/asyncapi/issues"


### PR DESCRIPTION
- License is `Apache-2.0`
- Added the missing `LICENSE` file
- Updated the `license` field on `package.json`

Additionally, updated the `author` and `contributors` information on `package.json`.