### PR TITLE
Small typo on section 'schemes'

### DIFF
--- a/README.md
+++ b/README.md
@@ -314,7 +314,7 @@ Value | Type | Description
 ```
 
 ```yaml
-host:
+schemes:
   - amqps
   - mqtts
 ```


### PR DESCRIPTION
The YAML example was 'host'  when it should be called 'schemes'.