### PR TITLE
Add servers object and remove host and schemes properties

### DIFF
--- a/README.md
+++ b/README.md
@@ -307,14 +307,14 @@ A single server would be described as:
 
 ```json
 {
-  "url": "//development.gigantic-server.com",
+  "url": "development.gigantic-server.com",
   "description": "Development server",
   "scheme": "mqtts"
 }
 ```
 
 ```yaml
-url: //development.gigantic-server.com
+url: development.gigantic-server.com
 description: Development server
 scheme: mqtts
 ```
@@ -325,17 +325,17 @@ The following shows how multiple servers can be described, for example, at the A
 {
   "servers": [
     {
-      "url": "//development.gigantic-server.com",
+      "url": "development.gigantic-server.com",
       "description": "Development server",
       "scheme": "mqtts"
     },
     {
-      "url": "//staging.gigantic-server.com",
+      "url": "staging.gigantic-server.com",
       "description": "Staging server",
       "scheme": "mqtts"
     },
     {
-      "url": "//api.gigantic-server.com",
+      "url": "api.gigantic-server.com",
       "description": "Production server",
       "scheme": "mqtts"
     }
@@ -345,13 +345,13 @@ The following shows how multiple servers can be described, for example, at the A
 
 ```yaml
 servers:
-- url: //development.gigantic-server.com
+- url: development.gigantic-server.com
   description: Development server
   scheme: mqtts
-- url: //staging.gigantic-server.com
+- url: staging.gigantic-server.com
   description: Staging server
   scheme: mqtts
-- url: //api.gigantic-server.com
+- url: api.gigantic-server.com
   description: Production server
   scheme: mqtts
 ```
@@ -362,7 +362,7 @@ The following shows how variables can be used for a server configuration:
 {
   "servers": [
     {
-      "url": "//{username}.gigantic-server.com:{port}/{basePath}",
+      "url": "{username}.gigantic-server.com:{port}/{basePath}",
       "description": "The production API server",
       "variables": {
         "username": {
@@ -387,7 +387,7 @@ The following shows how variables can be used for a server configuration:
 
 ```yaml
 servers:
-- url: //{username}.gigantic-server.com:{port}/{basePath}
+- url: {username}.gigantic-server.com:{port}/{basePath}
   description: The production API server
   variables:
     username:

--- a/README.md
+++ b/README.md
@@ -49,9 +49,8 @@ It means [processes](#definitionsProcess) can subscribe to `event.user.signup` t
 		- [Info Object](#infoObject)
 		- [Contact Object](#contactObject)
 		- [License Object](#licenseObject)
-		- [Host String](#hostString)
 		- [Base Topic String](#baseTopicString)
-		- [Schemes List](#schemesList)
+		- [Servers Object](#A2SServers)
 		- [Topics Object](#topicsObject)
 		- [Topic Item Object](#topicItemObject)
 		- [Message Object](#messageObject)
@@ -138,6 +137,7 @@ Field Name | Type | Description
 <a name="A2SAsyncAPI"></a>asyncapi | [AsyncAPI Version String](#A2SVersionString) | **Required.** Specifies the AsyncAPI Specification version being used. It can be used by tooling Specifications and clients to interpret the version. The structure shall be `major`.`minor`.`patch`, where `patch` versions _must_ be compatible with the existing `major`.`minor` tooling. Typically patch versions will be introduced to address errors in the documentation, and tooling should typically be compatible with the corresponding `major`.`minor` (1.0.*). Patch versions will correspond to patches of this document.
 <a name="A2SInfo"></a>info | [Info Object](#infoObject) | **Required.** Provides metadata about the API. The metadata can be used by the clients if needed.
 <a name="A2SBaseTopic"></a>baseTopic | [BaseTopic String](#baseTopicString) | The base topic to the API.
+<a name="A2SServers"></a>servers | [Server Object](#serverObject) | An array of [Server Objects](#serverObject), which provide connectivity information to a target server.
 <a name="A2STopics"></a>topics | [Topics Object](#topicsObject) | **Required.** The available topics and messages for the API.
 <a name="A2SComponents"></a>components | [Components Object](#componentsObject) | An element to hold various schemas for the specification.
 <a name="A2STags"></a>tags | [[Tag Object](#tagObject)] | A list of tags used by the specification with additional metadata. Each tag name in the list MUST be unique.
@@ -266,26 +266,10 @@ url: http://www.apache.org/licenses/LICENSE-2.0.html
 ```
 
 
-#### <a name="hostString"></a>Host String
-
-The host (name or ip) of the target server. This MAY point to a message broker.
-
-##### Host String Example:
-
-```json
-{
-  "host": "myapi.example.com"
-}
-```
-
-```yaml
-host: myapi.example.com
-```
 
 #### <a name="baseTopicString"></a>Base Topic String
 
 The base topic to the API. You MAY use this field to avoid repeating the beginning of the topics.
-
 
 ##### Base Topic String Example:
 
@@ -301,35 +285,144 @@ baseTopic: hitch.accounts
 
 
 
-#### <a name="schemesList"></a>Schemes List
 
-An array of the transfer protocol(s) the API supports. Values MUST be one (or more) of the following values:
+#### <a name="serverObject"></a>Server Object
 
-Value | Type | Description
+An object representing a Server.
+
+##### Fixed Fields
+
+Field Name | Type | Description
 ---|:---:|---
-<a name="schemesListValueAMQP"></a>amqp | `string` | AMQP protocol.
-<a name="schemesListValueAMQPS"></a>amqps | `string` | AMQP protocol over SSL/TLS.
-<a name="schemesListValueMQTT"></a>mqtt | `string` | MQTT protocol
-<a name="schemesListValueMQTTS"></a>mqtts | `string` | MQTT protocol over SSL/TLS.
-<a name="schemesListValueWS"></a>ws | `string` | WebSockets protocol
-<a name="schemesListValueWSS"></a>wss | `string` | WebSockets protocol over SSL/TLS.
-<a name="schemesListValueSTOMP"></a>stomp | `string` | STOMP protocol.
-<a name="schemesListValueSTOMPS"></a>stomps | `string` | STOMP protocol over SSL/TLS.
+<a name="serverObjectUrl"></a>url | `string` | **REQUIRED**. A URL to the target host.  This URL supports Server Variables and MAY be relative, to indicate that the host location is relative to the location where the AsyncAPI document is being served. Variable substitutions will be made when a variable is named in `{`brackets`}`.
+<a name="serverObjectScheme"></a>scheme | `string` | **REQUIRED**. The scheme this URL supports for connection. The value MUST be one of the following: `amqp`, `amqps`, `mqtt`, `mqtts`, `ws`, `wss`, `stomp`, `stomps`.
+<a name="serverObjectDescription"></a>description | `string` | An optional string describing the host designated by the URL. [CommonMark syntax](http://spec.commonmark.org/) MAY be used for rich text representation.
+<a name="serverObjectVariables"></a>variables | Map[`string`, [Server Variable Object](#serverVariableObject)] | A map between a variable name and its value.  The value is used for substitution in the server's URL template.
 
+This object MAY be extended with [Specification Extensions](#specificationExtensions).
 
-##### Schemes List Example:
+##### Server Object Example
+
+A single server would be described as:
 
 ```json
 {
-  "schemes": ["amqps", "mqtts"]
+  "url": "//development.gigantic-server.com",
+  "description": "Development server",
+  "scheme": "mqtts"
 }
 ```
 
 ```yaml
-schemes:
-  - amqps
-  - mqtts
+url: //development.gigantic-server.com
+description: Development server
+scheme: mqtts
 ```
+
+The following shows how multiple servers can be described, for example, at the AsyncAPI Object's [`servers`](#A2SServers):
+
+```json
+{
+  "servers": [
+    {
+      "url": "//development.gigantic-server.com",
+      "description": "Development server",
+      "scheme": "mqtts"
+    },
+    {
+      "url": "//staging.gigantic-server.com",
+      "description": "Staging server",
+      "scheme": "mqtts"
+    },
+    {
+      "url": "//api.gigantic-server.com",
+      "description": "Production server",
+      "scheme": "mqtts"
+    }
+  ]
+}
+```
+
+```yaml
+servers:
+- url: //development.gigantic-server.com
+  description: Development server
+  scheme: mqtts
+- url: //staging.gigantic-server.com
+  description: Staging server
+  scheme: mqtts
+- url: //api.gigantic-server.com
+  description: Production server
+  scheme: mqtts
+```
+
+The following shows how variables can be used for a server configuration:
+
+```json
+{
+  "servers": [
+    {
+      "url": "//{username}.gigantic-server.com:{port}/{basePath}",
+      "description": "The production API server",
+      "variables": {
+        "username": {
+          "default": "demo",
+          "description": "This value is assigned by the service provider, in this example `gigantic-server.com`"
+        },
+        "port": {
+          "enum": [
+            "8883",
+            "8884"
+          ],
+          "default": "8883"
+        },
+        "basePath": {
+          "default": "v2"
+        }
+      }
+    }
+  ]
+}
+```
+
+```yaml
+servers:
+- url: //{username}.gigantic-server.com:{port}/{basePath}
+  description: The production API server
+  variables:
+    username:
+      # note! no enum here means it is an open value
+      default: demo
+      description: This value is assigned by the service provider, in this example `gigantic-server.com`
+    port:
+      enum:
+        - '8883'
+        - '8884'
+      default: '8883'
+    basePath:
+      # open meaning there is the opportunity to use special base paths as assigned by the provider, default is `v2`
+      default: v2
+```
+
+
+#### <a name="serverVariableObject"></a>Server Variable Object
+
+An object representing a Server Variable for server URL template substitution.
+
+##### Fixed Fields
+
+Field Name | Type | Description
+---|:---:|---
+<a name="serverVariableObjectEnum"></a>enum | [`string`] | An enumeration of string values to be used if the substitution options are from a limited set.
+<a name="serverVariableObjectDefault"></a>default | `string` | The default value to use for substitution, and to send, if an alternate value is _not_ supplied.
+<a name="serverVariableObjectDescription"></a>description | `string` | An optional description for the server variable. [CommonMark syntax](http://spec.commonmark.org/) MAY be used for rich text representation.
+
+At least one of the fields MUST be provided.
+
+This object MAY be extended with [Specification Extensions](#specificationExtensions).
+
+
+
 
 
 #### <a name="topicsObject"></a>Topics Object

--- a/schema/asyncapi.json
+++ b/schema/asyncapi.json
@@ -26,19 +26,18 @@
     "info": {
       "$ref": "#/definitions/info"
     },
-    "host": {
-      "type": "string",
-      "pattern": "^[^{}/ :\\\\]+(?::\\d+)?$",
-      "description": "The host (name or ip) of the API. Example: 'asyncapi.hitchhq.com'"
-    },
     "baseTopic": {
       "type": "string",
       "pattern": "^[^/.]",
       "description": "The base topic to the API. Example: 'hitch'.",
       "default": ""
     },
-    "schemes": {
-      "$ref": "#/definitions/schemesList"
+    "servers": {
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/server"
+      },
+      "uniqueItems": true
     },
     "topics": {
       "$ref": "#/definitions/topics"
@@ -142,6 +141,77 @@
       "patternProperties": {
         "^x-": {
           "$ref": "#/definitions/vendorExtension"
+        }
+      }
+    },
+    "server": {
+      "type": "object",
+      "description": "An object representing a Server.",
+      "required": [
+        "url",
+        "scheme"
+      ],
+      "additionalProperties": false,
+      "patternProperties": {
+        "^x-": {
+          "$ref": "#/definitions/vendorExtension"
+        }
+      },
+      "properties": {
+        "url": {
+          "type": "string"
+        },
+        "description": {
+          "type": "string"
+        },
+        "scheme": {
+          "type": "string",
+          "description": "The transfer protocol.",
+          "enum": [
+            "amqp",
+            "amqps",
+            "mqtt",
+            "mqtts",
+            "ws",
+            "wss",
+            "stomp",
+            "stomps"
+          ]
+        },
+        "variables": {
+          "$ref": "#/definitions/serverVariables"
+        }
+      }
+    },
+    "serverVariables": {
+      "type": "object",
+      "additionalProperties": {
+        "$ref": "#/definitions/serverVariable"
+      }
+    },
+    "serverVariable": {
+      "type": "object",
+      "description": "An object representing a Server Variable for server URL template substitution.",      
+      "minProperties": 1,
+      "additionalProperties": false,
+      "patternProperties": {
+        "^x-": {
+          "$ref": "#/definitions/vendorExtension"
+        }
+      },
+      "properties": {
+        "enum": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "uniqueItems": true
+        },
+        "default": {
+          "type": "string"
+        },
+        "description": {
+          "type": "string"
         }
       }
     },
@@ -454,24 +524,6 @@
           "$ref": "#/definitions/vendorExtension"
         }
       }
-    },
-    "schemesList": {
-      "type": "array",
-      "description": "The transfer protocol(s) the API supports.",
-      "items": {
-        "type": "string",
-        "enum": [
-          "amqp",
-          "amqps",
-          "mqtt",
-          "mqtts",
-          "ws",
-          "wss",
-          "stomp",
-          "stomps"
-        ]
-      },
-      "uniqueItems": true
     },
     "title": {
       "$ref": "http://json-schema.org/draft-04/schema#/properties/title"

--- a/test/docs/sample.yml
+++ b/test/docs/sample.yml
@@ -8,10 +8,20 @@ info:
   termsOfService: |
     You can specify the terms of service here. **It supports Markdown as well.**
 baseTopic: 'hitch'
-host: asyncapi.hitchhq.com
-schemes:
-  - amqp
-  - mqtt
+
+servers:
+  - url: //api.company.com:{port}/{app-id}
+    description: Allows you to connect using the MQTT protocol.
+    scheme: mqtt
+    variables:
+      app-id:
+        default: demo
+        description: You can find your `app-id` in our control panel, under the auth tab.
+      port:
+        enum:
+          - '5676'
+          - '5677'
+        default: '5676'
 
 topics:
   accounts.1.0.action.user.signup:

--- a/test/docs/sample.yml
+++ b/test/docs/sample.yml
@@ -10,7 +10,7 @@ info:
 baseTopic: 'hitch'
 
 servers:
-  - url: //api.company.com:{port}/{app-id}
+  - url: api.company.com:{port}/{app-id}
     description: Allows you to connect using the MQTT protocol.
     scheme: mqtt
     variables:

--- a/test/docs/sample2.yml
+++ b/test/docs/sample2.yml
@@ -5,7 +5,7 @@ info:
 baseTopic: 'hitch'
 
 servers:
-  - url: //api.company.com:{port}/{app-id}
+  - url: api.company.com:{port}/{app-id}
     description: Allows you to connect using the MQTT protocol.
     scheme: mqtt
     variables:

--- a/test/docs/sample2.yml
+++ b/test/docs/sample2.yml
@@ -3,10 +3,20 @@ info:
   title: Sign up email example
   version: "1.0.0"
 baseTopic: 'hitch'
-host: asyncapi.hitchhq.com
-schemes:
-  - amqp
-  - mqtt
+
+servers:
+  - url: //api.company.com:{port}/{app-id}
+    description: Allows you to connect using the MQTT protocol.
+    scheme: mqtt
+    variables:
+      app-id:
+        default: demo
+        description: You can find your `app-id` in our control panel, under the auth tab.
+      port:
+        enum:
+          - '5676'
+          - '5677'
+        default: '5676'
 
 topics:
   accounts.1.0.event.user.signup:

--- a/test/docs/test-payload-string.yml
+++ b/test/docs/test-payload-string.yml
@@ -4,7 +4,7 @@ info:
   version: "1.0.0"
 
 servers:
-  - url: //wolksense.com:8883
+  - url: wolksense.com:8883
     description: WolkSense MQTT broker is hosted on wolksense.com on port 8883 and accepts SSL/TLS encrypted connections. Username/password authentication is used to identify MQTT clients and grant them access to specific topics.
     scheme: mqtts
 

--- a/test/docs/test-payload-string.yml
+++ b/test/docs/test-payload-string.yml
@@ -2,9 +2,11 @@ asyncapi: "1.0.0"
 info:
   title: Wolksense MQTT API
   version: "1.0.0"
-host: wolksense.com
-schemes:
-  - mqtts
+
+servers:
+  - url: //wolksense.com:8883
+    description: WolkSense MQTT broker is hosted on wolksense.com on port 8883 and accepts SSL/TLS encrypted connections. Username/password authentication is used to identify MQTT clients and grant them access to specific topics.
+    scheme: mqtts
 
 topics:
   sensors/{serialNumber}:

--- a/test/index.js
+++ b/test/index.js
@@ -9,7 +9,7 @@ const RefParser = require('json-schema-ref-parser');
 const validator = new ZSchema();
 
 loadJsonFile(path.resolve(__dirname, '../schema/asyncapi.json')).then(schema => {
-  fs.readFile(path.resolve(__dirname, 'docs/test-payload-string.yml'), (err, yaml) => {
+  fs.readFile(path.resolve(__dirname, 'docs/sample.yml'), (err, yaml) => {
     yaml = yaml.toString();
     const json = YAML.safeLoad(yaml);
     RefParser.dereference(json, {


### PR DESCRIPTION
This removes the host and schemes properties. For a better way to declare servers, protocols, etc. we followed the same approach as OpenAPI 3.0.0, using a `servers` object in the top level of the document. As discussed in https://github.com/asyncapi/asyncapi/issues/28.