### PR TITLE
Mark URL field as format 'uri'

### DIFF
--- a/schema/asyncapi.json
+++ b/schema/asyncapi.json
@@ -85,7 +85,8 @@
         },
         "termsOfService": {
           "type": "string",
-          "description": "A URL to the Terms of Service for the API. MUST be in the format of a URL."
+          "description": "A URL to the Terms of Service for the API. MUST be in the format of a URL.",
+          "format": "uri"
         },
         "contact": {
           "$ref": "#/definitions/contact"


### PR DESCRIPTION
To me it looks like as is if the `termsOfService` field is missing the URI format.