### PR TITLE
Add security schemes and requirements

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,6 +60,8 @@ It means [processes](#definitionsProcess) can subscribe to `event.user.signup` t
 		- [Reference Object](#referenceObject)
 		- [Schema Object](#schemaObject)
 		- [XML Object](#xmlObject)
+    - [Security Scheme Object](#securitySchemeObject)
+    - [Security Requirement Object](#securityRequirementObject)
 	- [Specification Extensions](#specificationExtensions)
 
 <!-- /TOC -->
@@ -140,6 +142,7 @@ Field Name | Type | Description
 <a name="A2SServers"></a>servers | [Server Object](#serverObject) | An array of [Server Objects](#serverObject), which provide connectivity information to a target server.
 <a name="A2STopics"></a>topics | [Topics Object](#topicsObject) | **Required.** The available topics and messages for the API.
 <a name="A2SComponents"></a>components | [Components Object](#componentsObject) | An element to hold various schemas for the specification.
+<a name="A2SSecurity"></a>security | [[Security Requirement Object](#securityRequirementObject)] | A declaration of which security mechanisms can be used across the API. The list of values includes alternative security requirement objects that can be used. Only one of the security requirement objects need to be satisfied to authorize a connection or operation.
 <a name="A2STags"></a>tags | [[Tag Object](#tagObject)] | A list of tags used by the specification with additional metadata. Each tag name in the list MUST be unique.
 <a name="A2SExternalDocs"></a>externalDocs | [External Documentation Object](#externalDocumentationObject) | Additional external documentation.
 
@@ -621,6 +624,57 @@ description: User-related messages
 
 
 
+#### <a name="referenceObject"></a>Reference Object
+
+A simple object to allow referencing other components in the specification, internally and externally.
+
+The Reference Object is defined by [JSON Reference](https://tools.ietf.org/html/draft-pbryan-zyp-json-ref-03) and follows the same structure, behavior and rules.
+
+For this specification, reference resolution is accomplished as defined by the JSON Reference specification and not by the JSON Schema specification.
+
+##### Fixed Fields
+Field Name | Type | Description
+---|:---:|---
+<a name="referenceRef"></a>$ref | `string` | **REQUIRED**. The reference string.
+
+This object cannot be extended with additional properties and any properties added SHALL be ignored.
+
+##### Reference Object Example
+
+```json
+{
+	"$ref": "#/components/schemas/Pet"
+}
+```
+
+```yaml
+$ref: '#/components/schemas/Pet'
+```
+
+##### Relative Schema Document Example
+```json
+{
+  "$ref": "Pet.json"
+}
+```
+
+```yaml
+$ref: Pet.yaml
+```
+
+##### Relative Documents With Embedded Schema Example
+```json
+{
+  "$ref": "definitions.json#/Pet"
+}
+```
+
+```yaml
+$ref: definitions.yaml#/Pet
+```
+
+
+
 
 #### <a name="externalDocumentationObject"></a>External Documentation Object
 
@@ -689,6 +743,7 @@ Field Name | Type | Description
 ---|:---|---
 <a name="componentsSchemas"></a> schemas | Map[`string`, [Schema Object](#schemaObject) \| [Reference Object](#referenceObject)] | An object to hold reusable [Schema Objects](#schemaObject).
 <a name="componentsMessages"></a> messages | Map[`string`, [Message Object](#messageObject) \| [Reference Object](#referenceObject)] | An object to hold reusable [Message Objects](#messageObject).
+<a name="componentsSecuritySchemes"></a> securitySchemes| Map[`string`, [Security Scheme Object](#securitySchemeObject) \| [Reference Object](#referenceObject)] | An object to hold reusable [Security Scheme Objects](#securitySchemeObject).
 
 This object can be extended with [Specification Extensions](#specificationExtensions).
 
@@ -1570,6 +1625,167 @@ animals:
 
 
 
+
+
+
+#### <a name="securitySchemeObject"></a>Security Scheme Object
+
+Defines a security scheme that can be used by the operations.
+Supported schemes are User/Password, API key (either as user or as password), X.509 certificate, end-to-end encryption (either symmetric or asymmetric), HTTP authentication and HTTP API key.
+
+##### Fixed Fields
+Field Name | Type | Applies To | Description
+---|:---:|---|---
+<a name="securitySchemeObjectType"></a>type | `string` | Any | **REQUIRED**. The type of the security scheme. Valid values are `"userPassword"`, `"apiKey"`, `"X509"`, `"symmetricEncryption"`, `"asymmetricEncryption"`, `"httpApiKey"`, `"http"`.
+<a name="securitySchemeObjectDescription"></a>description | `string` | Any | A short description for security scheme. [CommonMark syntax](http://spec.commonmark.org/) MAY be used for rich text representation.
+<a name="securitySchemeObjectName"></a>name | `string` | `httpApiKey` | **REQUIRED**. The name of the header, query or cookie parameter to be used.
+<a name="securitySchemeObjectIn"></a>in | `string` | `apiKey | httpApiKey` | **REQUIRED**. The location of the API key. Valid values are `"user"` and `"password"` for `apiKey` and `"query"`, `"header"` or `"cookie"` for `httpApiKey`.
+<a name="securitySchemeObjectScheme"></a>scheme | `string` | `http` | **REQUIRED**. The name of the HTTP Authorization scheme to be used in the [Authorization header as defined in RFC7235](https://tools.ietf.org/html/rfc7235#section-5.1).
+<a name="securitySchemeObjectBearerFormat"></a>bearerFormat | `string` | `http` (`"bearer"`) | A hint to the client to identify how the bearer token is formatted.  Bearer tokens are usually generated by an authorization server, so this information is primarily for documentation purposes.
+
+This object MAY be extended with [Specification Extensions](#specificationExtensions).
+
+##### Security Scheme Object Example
+
+###### User/Password Authentication Sample
+
+```json
+{
+  "type": "userPassword"
+}
+```
+
+```yaml
+type: userPassword
+```
+
+###### API Key Authentication Sample
+
+```json
+{
+  "type": "apiKey",
+  "in": "user"
+}
+```
+
+```yaml
+type: apiKey,
+in: user
+```
+
+###### X.509 Authentication Sample
+
+```json
+{
+  "type": "X509"
+}
+```
+
+```yaml
+type: X509
+```
+
+###### End-to-end Encryption Authentication Sample
+
+```json
+{
+  "type": "symmetricEncryption"
+}
+```
+
+```yaml
+type: symmetricEncryption
+```
+
+###### Basic Authentication Sample
+
+```json
+{
+  "type": "http",
+  "scheme": "basic"
+}
+```
+
+```yaml
+type: http
+scheme: basic
+```
+
+###### API Key Sample
+
+```json
+{
+  "type": "httpApiKey",
+  "name": "api_key",
+  "in": "header"
+}
+```
+
+```yaml
+type: httpApiKey
+name: api_key
+in: header
+```
+
+###### JWT Bearer Sample
+
+```json
+{
+  "type": "http",
+  "scheme": "bearer",
+  "bearerFormat": "JWT",
+}
+```
+
+```yaml
+type: http
+scheme: bearer
+bearerFormat: JWT
+```
+
+
+
+
+
+
+#### <a name="securityRequirementObject"></a>Security Requirement Object
+
+Lists the required security schemes to execute this operation.
+The name used for each property MUST correspond to a security scheme declared in the [Security Schemes](#componentsSecuritySchemes) under the [Components Object](#componentsObject).
+
+When a list of Security Requirement Objects is defined on the [AsyncAPI object](#A2SObject), only one of Security Requirement Objects in the list needs to be satisfied to authorize the connection or operation.
+
+##### Patterned Fields
+
+Field Pattern | Type | Description
+---|:---:|---
+<a name="securityRequirementsName"></a>{name} | [`string`] | Each name MUST correspond to a security scheme which is declared in the [Security Schemes](#componentsSecuritySchemes) under the [Components Object](#componentsObject). The value MUST be an empty array.
+
+##### Security Requirement Object Examples
+
+###### User/Password Security Requirement
+
+```json
+{
+  "user_pass": []
+}
+```
+
+```yaml
+user_pass: []
+```
+
+###### API Key Security Requirement
+
+```json
+{
+  "api_key": []
+}
+```
+
+```yaml
+api_key: []
+```
 
 
 

--- a/README.md
+++ b/README.md
@@ -624,55 +624,6 @@ description: User-related messages
 
 
 
-#### <a name="referenceObject"></a>Reference Object
-
-A simple object to allow referencing other components in the specification, internally and externally.
-
-The Reference Object is defined by [JSON Reference](https://tools.ietf.org/html/draft-pbryan-zyp-json-ref-03) and follows the same structure, behavior and rules.
-
-For this specification, reference resolution is accomplished as defined by the JSON Reference specification and not by the JSON Schema specification.
-
-##### Fixed Fields
-Field Name | Type | Description
----|:---:|---
-<a name="referenceRef"></a>$ref | `string` | **REQUIRED**. The reference string.
-
-This object cannot be extended with additional properties and any properties added SHALL be ignored.
-
-##### Reference Object Example
-
-```json
-{
-	"$ref": "#/components/schemas/Pet"
-}
-```
-
-```yaml
-$ref: '#/components/schemas/Pet'
-```
-
-##### Relative Schema Document Example
-```json
-{
-  "$ref": "Pet.json"
-}
-```
-
-```yaml
-$ref: Pet.yaml
-```
-
-##### Relative Documents With Embedded Schema Example
-```json
-{
-  "$ref": "definitions.json#/Pet"
-}
-```
-
-```yaml
-$ref: definitions.yaml#/Pet
-```
-
 
 
 

--- a/schema/asyncapi.json
+++ b/schema/asyncapi.json
@@ -52,11 +52,29 @@
       },
       "uniqueItems": true
     },
+    "security": {
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/SecurityRequirement"
+      }
+    },
     "externalDocs": {
       "$ref": "#/definitions/externalDocs"
     }
   },
   "definitions": {
+    "Reference": {
+      "type": "object",
+      "required": [
+        "$ref"
+      ],
+      "properties": {
+        "$ref": {
+          "type": "string",
+          "format": "uri"
+        }
+      }
+    },
     "info": {
       "type": "object",
       "description": "General information about the API.",
@@ -192,7 +210,7 @@
     },
     "serverVariable": {
       "type": "object",
-      "description": "An object representing a Server Variable for server URL template substitution.",      
+      "description": "An object representing a Server Variable for server URL template substitution.",
       "minProperties": 1,
       "additionalProperties": false,
       "patternProperties": {
@@ -239,6 +257,17 @@
         },
         "messages": {
           "$ref": "#/definitions/messages"
+        },
+        "securitySchemes": {
+          "type": "object",
+          "patternProperties": {
+            "^[a-zA-Z0-9\\.\\-_]+$": {
+              "oneOf": [
+                { "$ref": "#/definitions/Reference" },
+                { "$ref": "#/definitions/SecurityScheme" }
+              ]
+            }
+          }
         }
       }
     },
@@ -523,6 +552,246 @@
       "patternProperties": {
         "^x-": {
           "$ref": "#/definitions/vendorExtension"
+        }
+      }
+    },
+    "SecurityScheme": {
+      "oneOf": [
+        { "$ref": "#/definitions/userPassword" },
+        { "$ref": "#/definitions/apiKey" },
+        { "$ref": "#/definitions/X509" },
+        { "$ref": "#/definitions/symmetricEncryption" },
+        { "$ref": "#/definitions/asymmetricEncryption" },
+        { "$ref": "#/definitions/HTTPSecurityScheme" }
+      ]
+    },
+    "userPassword": {
+      "type": "object",
+      "required": [
+        "type"
+      ],
+      "properties": {
+        "type": {
+          "type": "string",
+          "enum": [
+            "userPassword"
+          ]
+        },
+        "description": {
+          "type": "string"
+        }
+      },
+      "patternProperties": {
+        "^x-": {}
+      },
+      "additionalProperties": false
+    },
+    "apiKey": {
+      "type": "object",
+      "required": [
+        "type",
+        "in"
+      ],
+      "properties": {
+        "type": {
+          "type": "string",
+          "enum": [
+            "apiKey"
+          ]
+        },
+        "in": {
+          "type": "string",
+          "enum": [
+            "user",
+            "password"
+          ]
+        },
+        "description": {
+          "type": "string"
+        }
+      },
+      "patternProperties": {
+        "^x-": {}
+      },
+      "additionalProperties": false
+    },
+    "X509": {
+      "type": "object",
+      "required": [
+        "type"
+      ],
+      "properties": {
+        "type": {
+          "type": "string",
+          "enum": [
+            "X509"
+          ]
+        },
+        "description": {
+          "type": "string"
+        }
+      },
+      "patternProperties": {
+        "^x-": {}
+      },
+      "additionalProperties": false
+    },
+    "symmetricEncryption": {
+      "type": "object",
+      "required": [
+        "type"
+      ],
+      "properties": {
+        "type": {
+          "type": "string",
+          "enum": [
+            "symmetricEncryption"
+          ]
+        },
+        "description": {
+          "type": "string"
+        }
+      },
+      "patternProperties": {
+        "^x-": {}
+      },
+      "additionalProperties": false
+    },
+    "asymmetricEncryption": {
+      "type": "object",
+      "required": [
+        "type"
+      ],
+      "properties": {
+        "type": {
+          "type": "string",
+          "enum": [
+            "asymmetricEncryption"
+          ]
+        },
+        "description": {
+          "type": "string"
+        }
+      },
+      "patternProperties": {
+        "^x-": {}
+      },
+      "additionalProperties": false
+    },
+    "HTTPSecurityScheme": {
+      "oneOf": [
+        { "$ref": "#/definitions/NonBearerHTTPSecurityScheme" },
+        { "$ref": "#/definitions/BearerHTTPSecurityScheme" },
+        { "$ref": "#/definitions/APIKeyHTTPSecurityScheme" }
+      ]
+    },
+    "NonBearerHTTPSecurityScheme": {
+      "not": {
+        "type": "object",
+        "properties": {
+          "scheme": {
+            "type": "string",
+            "enum": [
+              "bearer"
+            ]
+          }
+        }
+      },
+      "type": "object",
+      "required": [
+        "scheme",
+        "type"
+      ],
+      "properties": {
+        "scheme": {
+          "type": "string"
+        },
+        "description": {
+          "type": "string"
+        },
+        "type": {
+          "type": "string",
+          "enum": [
+            "http"
+          ]
+        }
+      },
+      "patternProperties": {
+        "^x-": {}
+      },
+      "additionalProperties": false
+    },
+    "BearerHTTPSecurityScheme": {
+      "type": "object",
+      "required": [
+        "type",
+        "scheme"
+      ],
+      "properties": {
+        "scheme": {
+          "type": "string",
+          "enum": [
+            "bearer"
+          ]
+        },
+        "bearerFormat": {
+          "type": "string"
+        },
+        "type": {
+          "type": "string",
+          "enum": [
+            "http"
+          ]
+        },
+        "description": {
+          "type": "string"
+        }
+      },
+      "patternProperties": {
+        "^x-": {}
+      },
+      "additionalProperties": false
+    },
+    "APIKeyHTTPSecurityScheme": {
+      "type": "object",
+      "required": [
+        "type",
+        "name",
+        "in"
+      ],
+      "properties": {
+        "type": {
+          "type": "string",
+          "enum": [
+            "httpApiKey"
+          ]
+        },
+        "name": {
+          "type": "string"
+        },
+        "in": {
+          "type": "string",
+          "enum": [
+            "header",
+            "query",
+            "cookie"
+          ]
+        },
+        "description": {
+          "type": "string"
+        }
+      },
+      "patternProperties": {
+        "^x-": {}
+      },
+      "additionalProperties": false
+    },
+    "SecurityRequirement": {
+      "type": "object",
+      "additionalProperties": {
+        "type": "array",
+        "items": {
+          "type": "string"
         }
       }
     },


### PR DESCRIPTION
It adds support for:

1. Defining security schemes inside the Components object.
2. Specify security requirements to authorize the connection.

#### Security schemes

As a result of an investigation about ways to protect your API using MQTT, AMQP and WebSockets, I came up with the following list:

1. User/Password: That's the most common when the API is private.
2. API Key (over User/Password): It feels like a hack to me but I've seen it in many places. It consists in sending an API token as the user or as the password when connecting to a system that expects a User/Password. Usually, the other field is left empty. For instance:
```yaml
user: AF89AFDKLK23423NADSFDS89AS79
password: (empty)
```
3. X.509 Certificate: That's very common for internal and/or partnership APIs.
4. End-to-end Encryption: Either symmetric or asymmetric. **I'm not sure this should be an auth scheme but another way to protect your API. Comments welcome :blush:**
5. HTTP: It's especially useful for WebSockets although suitable for other types of APIs. That's exactly the same as Open API's `http` scheme. It can be bearer or non-bearer (i.e. basic).
6. HTTP API Token: It's especially useful for WebSockets although suitable for other types of APIs. That's exactly the same as Open API's `apiKey` scheme. You can specify where the token is placed: header, query param or cookie.

#### Missing stuff

Support for security requirements object inside operations is still pending. It shouldn't be hard to add now, so feel free to make a PR :wink:.