### PR TITLE
Add support for Kafka

### DIFF
--- a/README.md
+++ b/README.md
@@ -298,7 +298,7 @@ An object representing a Server.
 Field Name | Type | Description
 ---|:---:|---
 <a name="serverObjectUrl"></a>url | `string` | **REQUIRED**. A URL to the target host.  This URL supports Server Variables and MAY be relative, to indicate that the host location is relative to the location where the AsyncAPI document is being served. Variable substitutions will be made when a variable is named in `{`brackets`}`.
-<a name="serverObjectScheme"></a>scheme | `string` | **REQUIRED**. The scheme this URL supports for connection. The value MUST be one of the following: `amqp`, `amqps`, `mqtt`, `mqtts`, `ws`, `wss`, `stomp`, `stomps`.
+<a name="serverObjectScheme"></a>scheme | `string` | **REQUIRED**. The scheme this URL supports for connection. The value MUST be one of the following: `kafka`, `kafka-secure`, `amqp`, `amqps`, `mqtt`, `mqtts`, `ws`, `wss`, `stomp`, `stomps`.
 <a name="serverObjectDescription"></a>description | `string` | An optional string describing the host designated by the URL. [CommonMark syntax](http://spec.commonmark.org/) MAY be used for rich text representation.
 <a name="serverObjectVariables"></a>variables | Map[`string`, [Server Variable Object](#serverVariableObject)] | A map between a variable name and its value.  The value is used for substitution in the server's URL template.
 

--- a/schema/asyncapi.json
+++ b/schema/asyncapi.json
@@ -186,6 +186,8 @@
           "type": "string",
           "description": "The transfer protocol.",
           "enum": [
+            "kafka",
+            "kafka-secure",
             "amqp",
             "amqps",
             "mqtt",


### PR DESCRIPTION
This PR adds support for Kafka. From now on you can also specify `kafka` and `kafka-secure` on a server scheme.

**Example:**

```yaml
servers:
  - url: kafka.company.com:9092
    description: Company's Kafka broker.
      scheme: kafka
```