### PR TITLE
Rename mqtts to secure-mqtt

### DIFF
--- a/README.md
+++ b/README.md
@@ -298,7 +298,7 @@ An object representing a Server.
 Field Name | Type | Description
 ---|:---:|---
 <a name="serverObjectUrl"></a>url | `string` | **REQUIRED**. A URL to the target host.  This URL supports Server Variables and MAY be relative, to indicate that the host location is relative to the location where the AsyncAPI document is being served. Variable substitutions will be made when a variable is named in `{`brackets`}`.
-<a name="serverObjectScheme"></a>scheme | `string` | **REQUIRED**. The scheme this URL supports for connection. The value MUST be one of the following: `kafka`, `kafka-secure`, `amqp`, `amqps`, `mqtt`, `mqtts`, `ws`, `wss`, `stomp`, `stomps`.
+<a name="serverObjectScheme"></a>scheme | `string` | **REQUIRED**. The scheme this URL supports for connection. The value MUST be one of the following: `kafka`, `kafka-secure`, `amqp`, `amqps`, `mqtt`, `secure-mqtt`, `ws`, `wss`, `stomp`, `stomps`.
 <a name="serverObjectSchemeVersion"></a>schemeVersion | `string` | The version of the scheme. For instance: AMQP `0.9.1`, Kafka `1.0.0`, etc.
 <a name="serverObjectDescription"></a>description | `string` | An optional string describing the host designated by the URL. [CommonMark syntax](http://spec.commonmark.org/) MAY be used for rich text representation.
 <a name="serverObjectVariables"></a>variables | Map[`string`, [Server Variable Object](#serverVariableObject)] | A map between a variable name and its value.  The value is used for substitution in the server's URL template.

--- a/schema/asyncapi.json
+++ b/schema/asyncapi.json
@@ -192,6 +192,7 @@
             "amqps",
             "mqtt",
             "mqtts",
+            "secure-mqtt",
             "ws",
             "wss",
             "stomp",


### PR DESCRIPTION
It now uses [IANA name for secure MQTT](https://www.iana.org/assignments/service-names-port-numbers/service-names-port-numbers.xhtml?search=secure-mqtt) (`secure-mqtt`) instead of `mqtts`.

The change is backward compatible. The schema still supports `mqtts` but it will be removed on the next major version.