### PR TITLE
Add support for Streaming APIs

### DIFF
--- a/README.md
+++ b/README.md
@@ -140,7 +140,8 @@ Field Name | Type | Description
 <a name="A2SInfo"></a>info | [Info Object](#infoObject) | **Required.** Provides metadata about the API. The metadata can be used by the clients if needed.
 <a name="A2SBaseTopic"></a>baseTopic | [BaseTopic String](#baseTopicString) | The base topic to the API.
 <a name="A2SServers"></a>servers | [Server Object](#serverObject) | An array of [Server Objects](#serverObject), which provide connectivity information to a target server.
-<a name="A2STopics"></a>topics | [Topics Object](#topicsObject) | **Required.** The available topics and messages for the API.
+<a name="A2STopics"></a>topics | [Topics Object](#topicsObject) | **Required unless [Stream Object](#streamObject) is provided.** The available topics and messages for the API.
+<a name="A2SStream"></a>stream | [Stream Object](#streamObject) | **Required unless [Topics Object](#topicsObject) is provided.** The messages and configuration for the streaming API.
 <a name="A2SComponents"></a>components | [Components Object](#componentsObject) | An element to hold various schemas for the specification.
 <a name="A2SSecurity"></a>security | [[Security Requirement Object](#securityRequirementObject)] | A declaration of which security mechanisms can be used across the API. The list of values includes alternative security requirement objects that can be used. Only one of the security requirement objects need to be satisfied to authorize a connection or operation.
 <a name="A2STags"></a>tags | [[Tag Object](#tagObject)] | A list of tags used by the specification with additional metadata. Each tag name in the list MUST be unique.
@@ -593,6 +594,90 @@ user.{userId}.signup:
     $ref: "#/components/messages/userSignedUp"
 ```
 
+
+
+
+
+#### <a name="streamObject"></a>Stream Object
+
+Holds the framing configuration and the read/write operations for the streaming API.
+
+##### Fixed Fields
+
+Field Name | Type | Description
+---|:---:|---
+<a name="streamObjectFraming"></a>framing | [Stream Framing Object](#streamFramingObject) | **Required.** The framing configuration for the streaming API, i.e., whether is `chunked` or `sse` and the frame delimiter.
+<a name="streamObjectRead"></a>read | [[Message Object](#messageObject)] | A list of messages a consumer can read from the API.
+<a name="streamObjectWrite"></a>write | [[Message Object](#messageObject)] | A list of messages a consumer can send to the API.
+
+Either `read` or `write` MUST be provided.
+
+This object can be extended with [Specification Extensions](#specificationExtensions).
+
+##### Stream Object Example
+
+```json
+{
+  "stream": {
+    "framing": {
+      "type": "chunked",
+      "delimiter": "\r\n"
+    },
+    "read": [
+      { "$ref": "#/components/messages/chatMessage" },
+      { "$ref": "#/components/messages/heartbeat" }
+    ]
+  }
+}
+```
+
+```yaml
+stream:
+  framing:
+    type: 'chunked'
+    delimiter: '\r\n'
+  read:
+    - $ref: '#/components/messages/chatMessage'
+    - $ref: '#/components/messages/heartbeat'
+```
+
+
+
+
+
+
+
+
+
+#### <a name="streamFramingObject"></a>Stream Framing Object
+
+Holds the framing configuration for the streaming API.
+
+##### Fixed Fields
+
+Field Name | Type | Description
+---|:---:|---
+<a name="streamFramingObjectType"></a>type | `string` | **Required.** The type of streaming API. Allowed values are `chunked` and `sse`.
+<a name="streamFramingObjectDelimiter"></a>delimiter | `string` | The string to use as the frame delimiter. Allowed values are `\r\n` and `\n`. Defaults to `\r\n`.
+
+This object can be extended with [Specification Extensions](#specificationExtensions).
+
+##### Stream Framing Object Example
+
+```json
+{
+  "framing": {
+    "type": "chunked",
+    "delimiter": "\r\n"
+  }
+}
+```
+
+```yaml
+framing:
+  type: 'chunked'
+  delimiter: '\r\n'
+```
 
 
 

--- a/schema/asyncapi.json
+++ b/schema/asyncapi.json
@@ -5,8 +5,19 @@
   "type": "object",
   "required": [
     "asyncapi",
-    "info",
-    "topics"
+    "info"
+  ],
+  "oneOf": [
+    {
+      "required": [
+        "topics"
+      ]
+    },
+    {
+      "required": [
+        "stream"
+      ]
+    }
   ],
   "additionalProperties": false,
   "patternProperties": {
@@ -19,7 +30,8 @@
       "type": "string",
       "enum": [
         "1.0.0",
-        "1.1.0"
+        "1.1.0",
+        "1.2.0"
       ],
       "description": "The AsyncAPI specification version of this document."
     },
@@ -41,6 +53,10 @@
     },
     "topics": {
       "$ref": "#/definitions/topics"
+    },
+    "stream": {
+      "$ref": "#/definitions/stream",
+      "description": "The list of messages a consumer can read or write from/to a streaming API."
     },
     "components": {
       "$ref": "#/definitions/components"
@@ -198,7 +214,9 @@
             "wss",
             "stomp",
             "stomps",
-            "jms"
+            "jms",
+            "http",
+            "https"
           ]
         },
         "schemeVersion": {
@@ -560,6 +578,86 @@
           }
         }
       ]
+    },
+    "stream": {
+      "title": "Stream Object",
+      "type": "object",
+      "additionalProperties": false,
+      "patternProperties": {
+        "^x-": {
+          "$ref": "#/definitions/vendorExtension"
+        }
+      },
+      "minProperties": 1,
+      "properties": {
+        "framing": {
+          "title": "Stream Framing Object",
+          "type": "object",
+          "patternProperties": {
+            "^x-": {
+              "$ref": "#/definitions/vendorExtension"
+            }
+          },
+          "minProperties": 1,
+          "oneOf": [
+            {
+              "additionalProperties": false,
+              "properties": {
+                "type": {
+                  "type": "string",
+                  "enum": [
+                    "chunked"
+                  ]
+                },
+                "delimiter": {
+                  "type": "string",
+                  "enum": [
+                    "\\r\\n",
+                    "\\n"
+                  ],
+                  "default": "\\r\\n"
+                }
+              }
+            },
+            {
+              "additionalProperties": false,
+              "properties": {
+                "type": {
+                  "type": "string",
+                  "enum": [
+                    "sse"
+                  ]
+                },
+                "delimiter": {
+                  "type": "string",
+                  "enum": [
+                    "\\n\\n"
+                  ],
+                  "default": "\\n\\n"
+                }
+              }
+            }
+          ]
+        },
+        "read": {
+          "title": "Stream Read Object",
+          "type": "array",
+          "uniqueItems": true,
+          "minItems": 1,
+          "items": {
+            "$ref": "#/definitions/message"
+          }
+        },
+        "write": {
+          "title": "Stream Write Object",
+          "type": "array",
+          "uniqueItems": true,
+          "minItems": 1,
+          "items": {
+            "$ref": "#/definitions/message"
+          }
+        }
+      }
     },
     "message": {
       "type": "object",

--- a/test/docs/gitter-streaming.yml
+++ b/test/docs/gitter-streaming.yml
@@ -1,0 +1,139 @@
+asyncapi: '1.2.0'
+info:
+  title: Gitter Streaming API
+  version: '1.0.0'
+
+servers:
+  - url: https://stream.gitter.im/v1/rooms/{roomId}/{resource}
+    scheme: https
+    schemeVersion: '1.1'
+    variables:
+      roomId:
+        description: Id of the Gitter room.
+      resource:
+        description: The resource to consume.
+        enum:
+          - chatMessages
+          - events
+
+security:
+  - httpBearerToken: []
+
+stream:
+  framing:
+    type: 'chunked'
+    delimiter: '\r\n'
+  read:
+    - $ref: '#/components/messages/chatMessage'
+    - $ref: '#/components/messages/heartbeat'
+
+components:
+  securitySchemes:
+    httpBearerToken:
+      type: http
+      scheme: bearer
+  messages:
+    chatMessage:
+      summary: >-
+        A message represents an individual chat message sent to a room.
+        They are a sub-resource of a room.
+      payload:
+        type: object
+        properties:
+          id:
+            type: string
+            description: ID of the message.
+          text:
+            type: string
+            description: Original message in plain-text/markdown.
+          html:
+            type: string
+            description: HTML formatted message.
+          sent:
+            type: string
+            format: date-time
+            description: ISO formatted date of the message.
+          fromUser:
+            type: object
+            description: User that sent the message.
+            properties:
+              id:
+                type: string
+                description: Gitter User ID.
+              username:
+                type: string
+                description: Gitter/GitHub username.
+              displayName:
+                type: string
+                description: Gitter/GitHub user real name.
+              url:
+                type: string
+                description: Path to the user on Gitter.
+              avatarUrl:
+                type: string
+                format: uri
+                description: User avatar URI.
+              avatarUrlSmall:
+                type: string
+                format: uri
+                description: User avatar URI (small).
+              avatarUrlMedium:
+                type: string
+                format: uri
+                description: User avatar URI (medium).
+              v:
+                type: number
+                description: Version.
+              gv:
+                type: string
+                description: Stands for "Gravatar version" and is used for cache busting.
+          unread:
+            type: boolean
+            description: Boolean that indicates if the current user has read the message.
+          readBy:
+            type: number
+            description: Number of users that have read the message.
+          urls:
+            type: array
+            description: List of URLs present in the message.
+            items:
+              type: string
+              format: uri
+          mentions:
+            type: array
+            description: List of @Mentions in the message.
+            items:
+              type: object
+              properties:
+                screenName:
+                  type: string
+                userId:
+                  type: string
+                userIds:
+                  type: array
+                  items:
+                    type: string
+          issues:
+            type: array
+            description: 'List of #Issues referenced in the message.'
+            items:
+              type: object
+              properties:
+                number:
+                  type: string
+          meta:
+            type: array
+            description: Metadata. This is currently not used for anything.
+            items: {}
+          v:
+            type: number
+            description: Version.
+          gv:
+            type: string
+            description: Stands for "Gravatar version" and is used for cache busting.
+
+    heartbeat:
+      summary: Its purpose is to keep the connection alive.
+      payload:
+        type: string
+        enum: ["\r\n"]


### PR DESCRIPTION
This PR adds support for defining streaming APIs.

It introduces a new root-level object called `stream`. It looks like this:

```yaml
stream:
  framing:
    type: 'chunked'
    delimiter: '\r\n'
      read:
        - $ref: '#/components/messages/chatMessage'
        - $ref: '#/components/messages/heartbeat'
```

**From now on, the `topics` object is not required if `stream` is present.**

\cc @jkarneges @MikeRalphson @kinlane