### PR TITLE
Re-usable parameters, fixes #71

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,9 +2,9 @@
 
 #### Disclaimer
 
-Part of this content has been taken from the great work done by the folks at the [Open API Initiative](https://openapis.org). Mainly because **it's a great work** and we want to keep as much compatibility as possible with the [Open API Specification](https://github.com/OAI/OpenAPI-Specification).
+Part of this content has been taken from the great work done by the folks at the [OpenAPI Initiative](https://openapis.org). Mainly because **it's a great work** and we want to keep as much compatibility as possible with the [OpenAPI Specification](https://github.com/OAI/OpenAPI-Specification).
 
-#### Version 1.1.0
+#### Version 1.2.0
 
 The key words "MUST", "MUST NOT", "REQUIRED", "SHALL", "SHALL NOT", "SHOULD", "SHOULD NOT", "RECOMMENDED", "MAY", and "OPTIONAL" in this document are to be interpreted as described in [RFC 2119](http://www.ietf.org/rfc/rfc2119.txt).
 
@@ -399,7 +399,7 @@ The following shows how variables can be used for a server configuration:
 
 ```yaml
 servers:
-- url: {username}.gigantic-server.com:{port}/{basePath}
+- url: '{username}.gigantic-server.com:{port}/{basePath}'
   description: The production API server
   variables:
     username:
@@ -482,7 +482,7 @@ Field Name | Type | Description
 <a name="topicItemObjectRef"></a>$ref | `string` | Allows for an external definition of this topic item. The referenced structure MUST be in the format of a [Topic Item Object](#topicItemObject). If there are conflicts between the referenced definition and this Topic Item's definition, the behavior is *undefined*.
 <a name="topicItemObjectSubscribe"></a>subscribe | [Message Object](#messageObject) &#124; Map[`"oneOf"`, [[Message Object](#messageObject)]] | A definition of the message a SUBSCRIBE operation will receive on this topic. `oneOf` is allowed here to specify multiple messages, however, **a message MUST be valid only against one of the referenced message objects.**
 <a name="topicItemObjectPublish"></a>publish | [Message Object](#messageObject) &#124; Map[`"oneOf"`, [[Message Object](#messageObject)]] | A definition of the message a PUBLISH operation will receive on this topic. `oneOf` is allowed here to specify multiple messages, however, **a message MUST be valid only against one of the referenced message objects.**
-<a name="topicItemObjectParameters"></a>parameters | [[Parameter Object](#parameterObject)] | A list of the parameters included in the topic name, if using [topic templating](#definitionsTopicTemplating).
+<a name="topicItemObjectParameters"></a>parameters | [[Parameter Object](#parameterObject) &#124; [Reference Object](#referenceObject)] | A list of the parameters included in the topic name, if using [topic templating](#definitionsTopicTemplating).
 
 This object can be extended with [Specification Extensions](#specificationExtensions).
 
@@ -779,6 +779,7 @@ Field Name | Type | Description
 <a name="componentsSchemas"></a> schemas | Map[`string`, [Schema Object](#schemaObject) \| [Reference Object](#referenceObject)] | An object to hold reusable [Schema Objects](#schemaObject).
 <a name="componentsMessages"></a> messages | Map[`string`, [Message Object](#messageObject) \| [Reference Object](#referenceObject)] | An object to hold reusable [Message Objects](#messageObject).
 <a name="componentsSecuritySchemes"></a> securitySchemes| Map[`string`, [Security Scheme Object](#securitySchemeObject) \| [Reference Object](#referenceObject)] | An object to hold reusable [Security Scheme Objects](#securitySchemeObject).
+<a name="componentsParameters"></a> parameters | Map[`string`, [Parameter Object](#parameterObject) \| [Reference Object](#referenceObject)] | An object to hold reusable [Parameter Objects](#parameterObject).
 
 This object can be extended with [Specification Extensions](#specificationExtensions).
 
@@ -859,6 +860,15 @@ my.org.User
         }
       }
     }
+  },
+  "parameters": {
+    "userId": {
+      "name": "userId",
+      "description": "Id of the user.",
+      "schema": {
+        "type": "string"
+      }
+    }
   }
 }
 ```
@@ -905,6 +915,12 @@ components:
             $ref: "#/components/schemas/userCreate"
           signup:
             $ref: "#/components/schemas/signup"
+  parameters:
+    userId:
+    - name: userId
+      description: Id of the user.
+      schema:
+        type: string
 ```
 
 #### <a name="schemaObject"></a>Schema Object

--- a/schema/asyncapi.json
+++ b/schema/asyncapi.json
@@ -19,7 +19,8 @@
       "type": "string",
       "enum": [
         "1.0.0",
-        "1.1.0"
+        "1.1.0",
+        "1.2.0"
       ],
       "description": "The AsyncAPI specification version of this document."
     },
@@ -275,6 +276,9 @@
               ]
             }
           }
+        },
+        "parameters": {
+          "$ref": "#/definitions/parameters"
         }
       }
     },
@@ -291,6 +295,13 @@
         "$ref": "#/definitions/message"
       },
       "description": "JSON objects describing the messages being consumed and produced by the API."
+    },
+    "parameters": {
+      "type": "object",
+      "additionalProperties": {
+        "$ref": "#/definitions/parameter"
+      },
+      "description": "JSON objects describing re-usable topic parameters."
     },
     "schema": {
       "type": "object",
@@ -534,7 +545,10 @@
         },
         "schema": {
           "$ref": "#/definitions/schema"
-        }
+        },
+        "$ref": {
+	  "type": "string"
+	}
       }
     },
     "operation": {

--- a/test/docs/sample.yml
+++ b/test/docs/sample.yml
@@ -1,4 +1,4 @@
-asyncapi: '1.1.0'
+asyncapi: '1.2.0'
 info:
   title: Streetlights API
   version: '1.0.0'
@@ -33,22 +33,25 @@ security:
 topics:
   event.{streetlightId}.lighting.measured:
     parameters:
-      - name: streetlightId
-        description: The ID of the streetlight.
-        schema:
-          type: string
+      - $ref: '#/components/parameters/streetlightId'
     publish:
       $ref: '#/components/messages/lightMeasured'
 
   action.{streetlightId}.turn.on:
+    parameters:
+      - $ref: '#/components/parameters/streetlightId'
     subscribe:
       $ref: '#/components/messages/turnOnOff'
 
   action.{streetlightId}.turn.off:
+    parameters:
+      - $ref: '#/components/parameters/streetlightId'
     subscribe:
       $ref: '#/components/messages/turnOnOff'
 
   action.{streetlightId}.dim:
+    parameters:
+      - $ref: '#/components/parameters/streetlightId'
     subscribe:
       $ref: '#/components/messages/dimLight'
 
@@ -108,3 +111,11 @@ components:
       type: apiKey
       in: user
       description: Provide your API key as the user and leave the password empty.
+
+  parameters:
+    streetlightId:
+      name: streetlightId
+      description: The ID of the streetlight.
+      schema:
+        type: string
+


### PR DESCRIPTION
* Parameter object expanded to include `$ref` property, as per schema etc
* Components object expanded to include `parameters` property
* Schema updated
* Sample doc updated
* Version bumped to 1.2.0 speculatively
* Minor fix to an example to ensure they all parse ok (mdv)
* "Open API Intiative" and "Open API Specification" -> "OpenAPI" as per recent change

Test passes.