### PR TITLE
Remove recommendation: Use a single AsyncAPI file.

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,8 +17,6 @@ The AsyncAPI Specification is a project used to describe and document Asynchrono
 The AsyncAPI Specification defines a set of files required to describe such an API.
 These files can then be used to create utilities, such as documentation, integration and/or testing tools.
 
-The AsyncAPI Specification is often used to describe the inter-process communication (IPC) in distributed systems built using a broker-centric architecture. In such cases, it's very easy to get confused with what the AsyncAPI files must describe. **It's RECOMMENDED to create a single file describing the whole system instead of creating a file for each [process](#definitionsProcess).** Otherwise, you will end up having lots of interdependent files.
-
 The file(s) MUST describe the operations a new [process](#definitionsProcess) can perform. For instance:
 
 ```yaml


### PR DESCRIPTION
I added this recommendation as a way to bypass the problem of having too many repeated message definitions across different AsyncAPI files, and potentially across many repos too. However, putting everything in a single file creates other types of challenges/problems, e.g.:

- API A can receive subscriptions on topic `my-topic`.
- API B publishes messages on topic `my-topic`.

Resulting asyncapi file would look like:

```yaml
topics:
  my-topic:
    subscribe:
      ... # For API A
    publish:
      ... # For API B
```

By looking at this file, you couldn't say what API A could do or what API B could do (except for the human-readable comments :trollface:).

This doesn't mean you shouldn't use this method. Go for it if that suits your needs, but **it's no longer a recommendation**.