### PR TITLE
Fix the license copyright holders

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -186,7 +186,8 @@
       same "printed page" as the copyright notice for easier
       identification within third-party archives.
 
-   Copyright 2017 Fran Méndez
+   Copyright 2017 API Changelog Ltd.
+   Copyright 2017-2018 Fran Méndez
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.


### PR DESCRIPTION
This PR adds a previously removed copyright holder to the `LICENSE` file. Additionally, it changes the copyright years for Fran Méndez to include 2018.