### PR TITLE
Add support for coap scheme

### DIFF
--- a/README.md
+++ b/README.md
@@ -298,7 +298,7 @@ An object representing a Server.
 Field Name | Type | Description
 ---|:---:|---
 <a name="serverObjectUrl"></a>url | `string` | **REQUIRED**. A URL to the target host.  This URL supports Server Variables and MAY be relative, to indicate that the host location is relative to the location where the AsyncAPI document is being served. Variable substitutions will be made when a variable is named in `{`brackets`}`.
-<a name="serverObjectScheme"></a>scheme | `string` | **REQUIRED**. The scheme this URL supports for connection. The value MUST be one of the following: `kafka`, `kafka-secure`, `amqp`, `amqps`, `mqtt`, `secure-mqtt`, `ws`, `wss`, `stomp`, `stomps`.
+<a name="serverObjectScheme"></a>scheme | `string` | **REQUIRED**. The scheme this URL supports for connection. The value MUST be one of the following: `kafka`, `kafka-secure`, `amqp`, `amqps`, `mqtt`, `secure-mqtt`, `ws`, `wss`, `stomp`, `stomps`, `jms` or `coap`.
 <a name="serverObjectSchemeVersion"></a>schemeVersion | `string` | The version of the scheme. For instance: AMQP `0.9.1`, Kafka `1.0.0`, etc.
 <a name="serverObjectDescription"></a>description | `string` | An optional string describing the host designated by the URL. [CommonMark syntax](http://spec.commonmark.org/) MAY be used for rich text representation.
 <a name="serverObjectVariables"></a>variables | Map[`string`, [Server Variable Object](#serverVariableObject)] | A map between a variable name and its value.  The value is used for substitution in the server's URL template.

--- a/schema/asyncapi.json
+++ b/schema/asyncapi.json
@@ -539,7 +539,8 @@
             "stomps",
             "http",
             "https",
-            "jms"
+            "jms",
+            "coap"
           ]
         },
         "schemeVersion": {

--- a/schema/asyncapi.yaml
+++ b/schema/asyncapi.yaml
@@ -454,6 +454,7 @@ definitions:
           - http
           - https
           - jms
+          - coap
       schemeVersion:
         description: TODO
         type: string

--- a/v2/CHANGELOG.md
+++ b/v2/CHANGELOG.md
@@ -13,6 +13,7 @@
   * [Callback messages.](#callback-messages)
   * [Support for "oneOf", "anyOf", and "not" on schemas.](#support-for-oneof-anyof-and-not-on-schemas)
   * [Override default topic separator.](#override-default-topic-separator)
+  * [Added CoAP scheme.](#added-coap-scheme)
 
 ## Descriptions
 
@@ -81,3 +82,8 @@ Kudos to [@wout3r](https://github.com/wout3r) and [@SensibleWood](https://github
 ### Override default topic separator
 
 It is now possible to override the default topic separator by specifying `defaultTopicSeparator`. This value will be used to concatenate the base topic (if it exists) with every topic. A common use case is to set it to `/` when documenting MQTT APIs.
+
+### Added CoAP scheme
+
+You can now use `coap` as a scheme. Thanks [@MikeRalphson](https://github.com/MikeRalphson).
+


### PR DESCRIPTION
Adds support for the Constrained Application Protocol [CoAP](https://en.wikipedia.org/wiki/Constrained_Application_Protocol) as a `scheme`.

Also add missing `jms` value from `scheme` description.