### PR TITLE
Add roadmap

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -1,0 +1,51 @@
+# AsyncAPI Roadmap
+
+## Project Mission and Summary
+AsyncAPI is a specification for defining message-driven APIs. We're in a mission to standardize message-based communication and increase interoperability of the different systems out there.
+
+## How to Get Involved?
+AsyncAPI is an open-source community-driven project. We're happy to receive contributions from different people, no matter your skills or your area of expertise. There are many ways you can contribute to the project, not just code. There is always a need for: documentation, design, writing, evangelizing, code, issue triage, and more! We also welcome financial support and donations. Check out the [contributing guidelines](./CONTRIBUTING.md) to learn more.
+
+## Timeline
+
+We're working hard to reach version 2.0.0, which will come full of great new features (and bug fixes.)
+
+> *If you're looking for dates, check out our [Milestones](https://github.com/asyncapi/asyncapi/milestones?direction=asc&sort=due_date) page.*
+
+### Current milestone
+
+:arrow_right: [[v2.0.0] Improving connectivity](https://github.com/asyncapi/asyncapi/milestone/1)
+
+This milestone tackles the issues related to connecting to a server. This is very important for SDKs and code generators.
+
+### Short term milestones
+
+:arrow_right: [[v2.0.0] Normalize topics and support multiple schemas](https://github.com/asyncapi/asyncapi/milestone/3)
+
+Before we continue heading to version 2.0.0, let's make the biggest breaking changes in the history of AsyncAPI: topic normalization and support for multiple schemas.
+
+:arrow_right: [[v2.0.0] Improve user experience](https://github.com/asyncapi/asyncapi/milestone/4)
+
+This milestone is about improving developer/user experience in, both, the specification and the tooling.
+
+### Medium/Long term milestones
+
+:arrow_right: [[v2.0.0] Augmentation](https://github.com/asyncapi/asyncapi/milestone/5)
+
+This milestone is about creating mechanisms for the users to augment the AsyncAPI specification. We already have specification extensions, which provide a syntactical way to extend the spec. In this milestone, we should aim for providing the right mechanisms to extend the spec in different contexts and ways.
+
+:arrow_right: [[v2.0.0] Protocol mappings](https://github.com/asyncapi/asyncapi/milestone/2)
+
+This milestone is about figuring out how to map protocols to AsyncAPI documents.
+
+:arrow_right: AsyncAPI version 2.0.0 Release Candidate launch
+
+There's a new AsyncAPI version and now it's time for the tooling vendors to finish implementing it.
+
+:arrow_right: :tada::tada::tada: AsyncAPI version 2.0.0 launch
+
+Official launch of AsyncAPI 2.0.0! Party hard! :beers:
+
+:arrow_right: [Backlog](https://github.com/asyncapi/asyncapi/projects/4)
+
+Backlog's purpose is to temporarily group issues that may be considered in the future. Please, note that it doesn't mean they will get implemented, however, there is a big chance.


### PR DESCRIPTION
### What?
It adds a roadmap document with 3 sections:
* Project mission and summary
* How to get involved
* Timeline

### Why?
[Let's make AsyncAPI a welcoming community](https://trello.com/b/2anfyIDT/lets-make-asyncapi-a-welcoming-community)

### Dependencies
* https://github.com/asyncapi/asyncapi/pull/106

### Extra
I followed [this document](https://mozillascience.github.io/working-open-workshop/roadmapping/).