### PR TITLE
Fix wording and link for meeting agendas

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,7 +77,7 @@ Meeting ID: 165 106 914
 * [+44 203 695 0088](tel:+442036950088)
 * [+44 203 051 2874](tel:+442030512874)
 
-Find the agenda for our past and next meetings in the [pinned issues](https://github.com/asyncapi/asyncapi/issues).
+Find the agenda for our past and future meetings [here](https://github.com/asyncapi/asyncapi/issues?utf8=%E2%9C%93&q=is%3Aissue+label%3Ameeting+sort%3Acreated-desc+).
 
 ## Meeting recordings
 


### PR DESCRIPTION
### What?
As @derberg correctly pointed out [here](https://github.com/asyncapi/asyncapi/pull/123/files#r254436884), I'm changing the words and the link for past and future meeting agendas.

### Why?
It was really confusing.