### PR TITLE
Automate testing against all examples

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,3 +3,4 @@ node_js:
   - "6"
 script:
   - npm run test
+  - npm run mdv

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: node_js
 node_js:
-  - "6"
+  - "10"
 script:
   - npm run test
   - npm run mdv

--- a/package-lock.json
+++ b/package-lock.json
@@ -36,6 +36,14 @@
         "sprintf-js": "~1.0.2"
       }
     },
+    "async": {
+      "version": "2.6.1",
+      "resolved": "https://registry.npmjs.org/async/-/async-2.6.1.tgz",
+      "integrity": "sha512-fNEiL2+AZt6AlAw/29Cr0UDe4sRAHCpEHh54WMz+Bb7QfNcFw4h3loofyJpLeQs4Yx7yuqu/2dLgM5hKOs6HlQ==",
+      "requires": {
+        "lodash": "^4.17.10"
+      }
+    },
     "boolbase": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/boolbase/-/boolbase-1.0.0.tgz",
@@ -88,6 +96,11 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/code-point-at/-/code-point-at-1.1.0.tgz",
       "integrity": "sha1-DQcLTQQ6W+ozovGkDi7bPZpMz3c="
+    },
+    "colors": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/colors/-/colors-1.3.3.tgz",
+      "integrity": "sha512-mmGt/1pZqYRjMxB1axhTo16/snVZ5krrKkcmMeVKxzECMMXoCgnvTPp10QgHfcbQZw8Dq2jMNG6je4JlWU0gWg=="
     },
     "commander": {
       "version": "2.19.0",
@@ -192,14 +205,6 @@
       "resolved": "https://registry.npmjs.org/entities/-/entities-1.1.2.tgz",
       "integrity": "sha512-f2LZMYl1Fzu7YSBKg+RoROelpOaNrcGmE9AZubeDfrCEia483oW4MI4VyFd5VNHIgQ/7qm1I0wUHK1eJnn2y2w=="
     },
-    "error-ex": {
-      "version": "1.3.2",
-      "resolved": "https://registry.npmjs.org/error-ex/-/error-ex-1.3.2.tgz",
-      "integrity": "sha512-7dFHNmqeFSEt2ZBsCriorKnn3Z2pj+fd9kmI6QoWw4//DL+icEBfc0U7qJCisqrTsKTjw4fNFy2pW9OqStD84g==",
-      "requires": {
-        "is-arrayish": "^0.2.1"
-      }
-    },
     "es6-promise": {
       "version": "4.2.5",
       "resolved": "https://registry.npmjs.org/es6-promise/-/es6-promise-4.2.5.tgz",
@@ -247,6 +252,14 @@
       "resolved": "https://registry.npmjs.org/format-util/-/format-util-1.0.3.tgz",
       "integrity": "sha1-Ay3KShFiYqEsQ/TD7IVmQWxbLZU="
     },
+    "fs-walk": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/fs-walk/-/fs-walk-0.0.2.tgz",
+      "integrity": "sha1-IhA4W9vDKrUZM87lAu8YUWeXYE0=",
+      "requires": {
+        "async": "*"
+      }
+    },
     "get-caller-file": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-1.0.3.tgz",
@@ -259,11 +272,6 @@
       "requires": {
         "pump": "^3.0.0"
       }
-    },
-    "graceful-fs": {
-      "version": "4.1.11",
-      "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.11.tgz",
-      "integrity": "sha1-Dovf5NHduIVNZOBOp8AOKgJuVlg="
     },
     "htmlparser2": {
       "version": "3.10.0",
@@ -287,11 +295,6 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/invert-kv/-/invert-kv-2.0.0.tgz",
       "integrity": "sha512-wPVv/y/QQ/Uiirj/vh3oP+1Ww+AWehmi1g5fFWGPF6IpCBCDVrhgHRMvrLfdYcwDh3QJbGXDW4JAuzxElLSqKA=="
-    },
-    "is-arrayish": {
-      "version": "0.2.1",
-      "resolved": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.2.1.tgz",
-      "integrity": "sha1-d8mYQFJ6qOyxqLppe4BkWnqSap0="
     },
     "is-fullwidth-code-point": {
       "version": "2.0.0",
@@ -356,17 +359,6 @@
         "uc.micro": "^1.0.1"
       }
     },
-    "load-json-file": {
-      "version": "2.0.0",
-      "resolved": "http://registry.npmjs.org/load-json-file/-/load-json-file-2.0.0.tgz",
-      "integrity": "sha1-eUfkIUmvgNaWy/eXvKq8/h/inKg=",
-      "requires": {
-        "graceful-fs": "^4.1.2",
-        "parse-json": "^2.2.0",
-        "pify": "^2.0.0",
-        "strip-bom": "^3.0.0"
-      }
-    },
     "locate-path": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-3.0.0.tgz",
@@ -375,6 +367,11 @@
         "p-locate": "^3.0.0",
         "path-exists": "^3.0.0"
       }
+    },
+    "lodash": {
+      "version": "4.17.11",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.11.tgz",
+      "integrity": "sha512-cQKh8igo5QUhZ7lg38DYWAxMvjSAKG0A8wGSVimP07SIUEK2UO+arSRKbRZWtelMtN5V0Hkwh5ryOto/SshYIg=="
     },
     "lodash.assignin": {
       "version": "4.2.0",
@@ -592,14 +589,6 @@
       "resolved": "https://registry.npmjs.org/p-try/-/p-try-2.0.0.tgz",
       "integrity": "sha512-hMp0onDKIajHfIkdRk3P4CdCmErkYAxxDtP3Wx/4nZ3aGlau2VKh3mZpcuFkH27WQkL/3WBCPOktzA9ZOAnMQQ=="
     },
-    "parse-json": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-2.2.0.tgz",
-      "integrity": "sha1-9ID0BDTvgHQfhGkJn43qGPVaTck=",
-      "requires": {
-        "error-ex": "^1.2.0"
-      }
-    },
     "path-exists": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-3.0.0.tgz",
@@ -609,11 +598,6 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/path-key/-/path-key-2.0.1.tgz",
       "integrity": "sha1-QRyttXTFoUDTpLGRDUDYDMn0C0A="
-    },
-    "pify": {
-      "version": "2.3.0",
-      "resolved": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
-      "integrity": "sha1-7RQaasBDqEnqWISY59yosVMw6Qw="
     },
     "pump": {
       "version": "3.0.0",
@@ -716,11 +700,6 @@
       "requires": {
         "ansi-regex": "^3.0.0"
       }
-    },
-    "strip-bom": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-3.0.0.tgz",
-      "integrity": "sha1-IzTBjpx1n3vdVv3vfprj1YjmjtM="
     },
     "strip-eof": {
       "version": "1.0.0",

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "AsyncAPI specification",
   "scripts": {
     "mdv": "mdv versions/**/*.md",
-    "test": "node test/index.js && npm run mdv"
+    "test": "node test/index.js"
   },
   "private": true,
   "repository": {

--- a/package.json
+++ b/package.json
@@ -28,9 +28,10 @@
   "homepage": "https://github.com/asyncapi/asyncapi#readme",
   "dependencies": {
     "ajv": "^6.8.1",
+    "colors": "^1.3.3",
+    "fs-walk": "0.0.2",
     "js-yaml": "^3.7.0",
     "json-schema-ref-parser": "^3.1.2",
-    "load-json-file": "^2.0.0",
     "mdv": "^1.1.0"
   }
 }

--- a/test/index.js
+++ b/test/index.js
@@ -67,8 +67,20 @@ const runForVersion = version => new Promise((resolve, reject) => {
   });
 });
 
+// RUNNING TESTS
+
+let versions = ['1.1.0', '1.2.0', 'next'];
+
+if (process.argv.length > 2) {
+  const args = process.argv.slice(2);
+  const indexOfVersions = args.indexOf('--versions');
+  if (indexOfVersions > -1) versions = args[indexOfVersions + 1].split(',');
+}
+
+console.log(`Running tests for versions: ${versions.join(', ')}\n`.white.bold.underline);
+
 Promise.all(
-  ['1.1.0', '1.2.0', 'next'].map(runForVersion)
+  versions.map(runForVersion)
 ).then(() => {
   console.log('\nThe future looks bright ✨'.green);
 }).catch((e) => {

--- a/test/index.js
+++ b/test/index.js
@@ -1,3 +1,5 @@
+// Usage: npm test [-- --versions 1.2.0,next]
+
 const util = require('util');
 const fs = require('fs');
 const path = require('path');

--- a/test/index.js
+++ b/test/index.js
@@ -2,32 +2,75 @@ const util = require('util');
 const fs = require('fs');
 const path = require('path');
 const Ajv = require('ajv');
-const loadJsonFile = require('load-json-file');
 const YAML = require('js-yaml');
 const RefParser = require('json-schema-ref-parser');
+const walk = require('fs-walk');
+require('colors');
 
-loadJsonFile(path.resolve(__dirname, '../versions/1.2.0/schema.json')).then(schema => {
-  fs.readFile(path.resolve(__dirname, '../examples/1.2.0/streetlights.yml'), (err, yaml) => {
-    yaml = yaml.toString();
-    const json = YAML.safeLoad(yaml);
-    RefParser.dereference(json, {
+const validate = async (content, schema) => {
+  let json = YAML.safeLoad(content);
+
+  try {
+    json = await RefParser.dereference(json, {
       dereference: {
         circular: 'ignore'
       }
-    }).then((json) => {
-      const ajv = new Ajv({schemaId: 'auto'});
-
-      ajv.addMetaSchema(require('ajv/lib/refs/json-schema-draft-04.json'));
-
-      const valid = ajv.validate(schema, json);
-
-      if (!valid) return console.error(ajv.errors);
-      console.log(util.inspect(json, { depth: null, colors: true }));
-      console.log('Valid:', valid);
-    }).catch((err) => {
-      console.error(err);
     });
+
+    const ajv = new Ajv({ schemaId: 'auto' });
+    ajv.addMetaSchema(require('ajv/lib/refs/json-schema-draft-04.json'));
+
+    const valid = ajv.validate(schema, json);
+
+    if (!valid) {
+      return {
+        valid: false,
+        errors: ajv.errors,
+      };
+    }
+
+    return {
+      valid: true,
+    };
+  } catch (e) {
+    throw e;
+  }
+};
+
+const runForVersion = version => new Promise((resolve, reject) => {
+  const schema = require(path.resolve(__dirname, '../versions/', version, 'schema.json'));
+
+  walk.walk(path.resolve(__dirname, '../examples/', version), async (basedir, filename, stat, next) => {
+    if (!filename.match(/\.(y[a]?ml)|(json)$/)) return next();
+
+    process.stdout.write(`Running test for ${filename} (version ${version})... `.cyan);
+    const content = fs.readFileSync(path.resolve(basedir, filename)).toString();
+    try {
+      const result = await validate(content, schema);
+
+      if (result.valid) {
+        process.stdout.write('OK\n'.green);
+        return next();
+      }
+      
+      console.error('FAILED\n'.red);
+      console.error('Error details:\n'.red.underline);
+      console.error(util.inspect(result.errors, { depth: null, colors: true }));
+      result.errors.logged = true;
+      next(result.errors);
+    } catch (e) {
+      next(e);
+    }
+  }, (err) => {
+    if (err) return reject(err);
+    resolve();
   });
-}).catch(err => {
-  console.error(err);
+});
+
+Promise.all(
+  ['1.1.0', '1.2.0', 'next'].map(runForVersion)
+).then(() => {
+  console.log('\nThe future looks bright ✨'.green);
+}).catch((e) => {
+  if (e && !e.logged) console.error(e);
 });


### PR DESCRIPTION
### What?
I just improved "tests" a little bit. It now runs tests for every document in the examples directory. You can also select which versions you want to run.

### Example

Run tests for specific versions:
```bash
npm test -- --versions 1.2.0,next
```

### Why?
It's very convenient while working on the spec.

### Screenshots
![screen shot 2019-02-11 at 11 50 06](https://user-images.githubusercontent.com/242119/52558638-45a11c00-2df3-11e9-89b5-6b54426e1169.png)

![screen shot 2019-02-11 at 11 51 08](https://user-images.githubusercontent.com/242119/52558653-5b164600-2df3-11e9-9492-b1eff70ade84.png)
