### PR TITLE
Rename topics to channels and remove events

### DIFF
--- a/examples/next/anyof.yml
+++ b/examples/next/anyof.yml
@@ -1,0 +1,29 @@
+asyncapi: '2.0.0'
+info:
+  title: AnyOf example
+  version: '1.0.0'
+
+channels:
+  test:
+    publish:
+      $ref: '#/components/messages/testMessages'
+
+components:
+  messages:
+    testMessages:
+      payload:
+        anyOf: # anyOf in payload schema
+          - $ref: "#/components/schemas/objectWithKey"
+          - $ref: "#/components/schemas/objectWithKey2"
+
+  schemas:
+    objectWithKey:
+      type: object
+      properties:
+        key:
+          type: string
+    objectWithKey2:
+      type: object
+      properties:
+        key2:
+          type: string

--- a/examples/next/gitter-streaming.yml
+++ b/examples/next/gitter-streaming.yml
@@ -1,0 +1,139 @@
+asyncapi: '2.0.0'
+info:
+  title: Gitter Streaming API
+  version: '1.0.0'
+
+servers:
+  - url: https://stream.gitter.im/v1/rooms/{roomId}/{resource}
+    scheme: https
+    schemeVersion: '1.1'
+    variables:
+      roomId:
+        description: Id of the Gitter room.
+      resource:
+        description: The resource to consume.
+        enum:
+          - chatMessages
+          - events
+
+security:
+  - httpBearerToken: []
+
+stream:
+  framing:
+    type: 'chunked'
+    delimiter: '\r\n'
+  read:
+    - $ref: '#/components/messages/chatMessage'
+    - $ref: '#/components/messages/heartbeat'
+
+components:
+  securitySchemes:
+    httpBearerToken:
+      type: http
+      scheme: bearer
+  messages:
+    chatMessage:
+      summary: >-
+        A message represents an individual chat message sent to a room.
+        They are a sub-resource of a room.
+      payload:
+        type: object
+        properties:
+          id:
+            type: string
+            description: ID of the message.
+          text:
+            type: string
+            description: Original message in plain-text/markdown.
+          html:
+            type: string
+            description: HTML formatted message.
+          sent:
+            type: string
+            format: date-time
+            description: ISO formatted date of the message.
+          fromUser:
+            type: object
+            description: User that sent the message.
+            properties:
+              id:
+                type: string
+                description: Gitter User ID.
+              username:
+                type: string
+                description: Gitter/GitHub username.
+              displayName:
+                type: string
+                description: Gitter/GitHub user real name.
+              url:
+                type: string
+                description: Path to the user on Gitter.
+              avatarUrl:
+                type: string
+                format: uri
+                description: User avatar URI.
+              avatarUrlSmall:
+                type: string
+                format: uri
+                description: User avatar URI (small).
+              avatarUrlMedium:
+                type: string
+                format: uri
+                description: User avatar URI (medium).
+              v:
+                type: number
+                description: Version.
+              gv:
+                type: string
+                description: Stands for "Gravatar version" and is used for cache busting.
+          unread:
+            type: boolean
+            description: Boolean that indicates if the current user has read the message.
+          readBy:
+            type: number
+            description: Number of users that have read the message.
+          urls:
+            type: array
+            description: List of URLs present in the message.
+            items:
+              type: string
+              format: uri
+          mentions:
+            type: array
+            description: List of @Mentions in the message.
+            items:
+              type: object
+              properties:
+                screenName:
+                  type: string
+                userId:
+                  type: string
+                userIds:
+                  type: array
+                  items:
+                    type: string
+          issues:
+            type: array
+            description: 'List of #Issues referenced in the message.'
+            items:
+              type: object
+              properties:
+                number:
+                  type: string
+          meta:
+            type: array
+            description: Metadata. This is currently not used for anything.
+            items: {}
+          v:
+            type: number
+            description: Version.
+          gv:
+            type: string
+            description: Stands for "Gravatar version" and is used for cache busting.
+
+    heartbeat:
+      summary: Its purpose is to keep the connection alive.
+      payload:
+        type: string
+        enum: ["\r\n"]

--- a/examples/next/not.yml
+++ b/examples/next/not.yml
@@ -1,0 +1,23 @@
+asyncapi: '2.0.0'
+info:
+  title: Not example
+  version: '1.0.0'
+
+channels:
+  test:
+    publish:
+      $ref: '#/components/messages/testMessages'
+
+components:
+  messages:
+    testMessages:
+      payload:
+        $ref: "#/components/schemas/testSchema"
+
+  schemas:
+    testSchema:
+      type: object
+      properties:
+        key:
+          not:
+            type: integer

--- a/examples/next/oneof.yml
+++ b/examples/next/oneof.yml
@@ -1,0 +1,44 @@
+asyncapi: '2.0.0'
+info:
+  title: OneOf example
+  version: '1.0.0'
+
+channels:
+  test:
+    publish:
+      $ref: '#/components/messages/testMessages'
+
+  test2:
+    subscribe:
+      # Use oneOf here if different messages are published on test2 topic.
+      oneOf:
+        - payload:
+            $ref: "#/components/schemas/objectWithKey"
+        - payload:
+            $ref: "#/components/schemas/objectWithKey2"
+
+components:
+  messages:
+    testMessages:
+      payload:
+        oneOf: # oneOf in payload schema
+          - $ref: "#/components/schemas/objectWithKey"
+          - $ref: "#/components/schemas/objectWithKey2"
+    testMessage1:
+      payload:
+        $ref: "#/components/schemas/objectWithKey"
+    testMessage2:
+      payload:
+        $ref: "#/components/schemas/objectWithKey2"
+
+  schemas:
+    objectWithKey:
+      type: object
+      properties:
+        key:
+          type: string
+    objectWithKey2:
+      type: object
+      properties:
+        key2:
+          type: string

--- a/examples/next/slack-rtm.yml
+++ b/examples/next/slack-rtm.yml
@@ -1,0 +1,878 @@
+asyncapi: '2.0.0'
+info:
+  title: Slack Real Time Messaging API
+  version: '1.0.0'
+
+servers:
+  - url: https://slack.com/api/rtm.connect
+    scheme: https
+    schemeVersion: '1.1'
+
+security:
+  - token: []
+
+channels:
+  /:
+    subscribe:
+      oneOf:
+        - $ref: '#/components/messages/hello'
+        - $ref: '#/components/messages/connectionError'
+        - $ref: '#/components/messages/accountsChanged'
+        - $ref: '#/components/messages/botAdded'
+        - $ref: '#/components/messages/botChanged'
+        - $ref: '#/components/messages/channelArchive'
+        - $ref: '#/components/messages/channelCreated'
+        - $ref: '#/components/messages/channelDeleted'
+        - $ref: '#/components/messages/channelHistoryChanged'
+        - $ref: '#/components/messages/channelJoined'
+        - $ref: '#/components/messages/channelLeft'
+        - $ref: '#/components/messages/channelMarked'
+        - $ref: '#/components/messages/channelRename'
+        - $ref: '#/components/messages/channelUnarchive'
+        - $ref: '#/components/messages/commandsChanged'
+        - $ref: '#/components/messages/dndUpdated'
+        - $ref: '#/components/messages/dndUpdatedUser'
+        - $ref: '#/components/messages/emailDomainChanged'
+        - $ref: '#/components/messages/emojiRemoved'
+        - $ref: '#/components/messages/emojiAdded'
+        - $ref: '#/components/messages/fileChange'
+        - $ref: '#/components/messages/fileCommentAdded'
+        - $ref: '#/components/messages/fileCommentDeleted'
+        - $ref: '#/components/messages/fileCommentEdited'
+        - $ref: '#/components/messages/fileCreated'
+        - $ref: '#/components/messages/fileDeleted'
+        - $ref: '#/components/messages/filePublic'
+        - $ref: '#/components/messages/fileShared'
+        - $ref: '#/components/messages/fileUnshared'
+        - $ref: '#/components/messages/goodbye'
+        - $ref: '#/components/messages/groupArchive'
+        - $ref: '#/components/messages/groupClose'
+        - $ref: '#/components/messages/groupHistoryChanged'
+        - $ref: '#/components/messages/groupJoined'
+        - $ref: '#/components/messages/groupLeft'
+        - $ref: '#/components/messages/groupMarked'
+        - $ref: '#/components/messages/groupOpen'
+        - $ref: '#/components/messages/groupRename'
+        - $ref: '#/components/messages/groupUnarchive'
+        - $ref: '#/components/messages/imClose'
+        - $ref: '#/components/messages/imCreated'
+        - $ref: '#/components/messages/imMarked'
+        - $ref: '#/components/messages/imOpen'
+        - $ref: '#/components/messages/manualPresenceChange'
+        - $ref: '#/components/messages/memberJoinedChannel'
+        - $ref: '#/components/messages/message'
+    publish:
+      $ref: '#/components/messages/outgoingMessage'
+
+components:
+  securitySchemes:
+    token:
+      type: httpApiKey
+      name: token
+      in: query
+
+  schemas:
+    attachment:
+      type: object
+      properties:
+        fallback:
+          type: string
+        color:
+          type: string
+        pretext:
+          type: string
+        author_name:
+          type: string
+        author_link:
+          type: string
+          format: uri
+        author_icon:
+          type: string
+          format: uri
+        title:
+          type: string
+        title_link:
+          type: string
+          format: uri
+        text:
+          type: string
+        fields:
+          type: array
+          items:
+            type: object
+            properties:
+              title:
+                type: string
+              value:
+                type: string
+              short:
+                type: boolean
+        image_url:
+          type: string
+          format: uri
+        thumb_url:
+          type: string
+          format: uri
+        footer:
+          type: string
+        footer_icon:
+          type: string
+          format: uri
+        ts:
+          type: number
+
+  messages:
+    hello:
+      summary: First event received upon connection.
+      payload:
+        type: object
+        properties:
+          type:
+            type: string
+            enum: ['hello']
+
+    connectionError:
+      summary: Event received when a connection error happens.
+      payload:
+        type: object
+        properties:
+          type:
+            type: string
+            enum: ['error']
+          error:
+            type: object
+            properties:
+              code:
+                type: number
+              msg:
+                type: string
+
+    accountsChanged:
+      summary: The list of accounts a user is signed into has changed.
+      payload:
+        type: object
+        properties:
+          type:
+            type: string
+            enum: ['accounts_changed']
+
+    botAdded:
+      summary: A bot user was added.
+      payload:
+        type: object
+        properties:
+          type:
+            type: string
+            enum: ['bot_added']
+          bot:
+            type: object
+            properties:
+              id:
+                type: string
+              app_id:
+                type: string
+              name:
+                type: string
+              icons:
+                type: object
+                additionalProperties:
+                  type: string
+
+    botChanged:
+      summary: A bot user was changed.
+      payload:
+        type: object
+        properties:
+          type:
+            type: string
+            enum: ['bot_added']
+          bot:
+            type: object
+            properties:
+              id:
+                type: string
+              app_id:
+                type: string
+              name:
+                type: string
+              icons:
+                type: object
+                additionalProperties:
+                  type: string
+
+    channelArchive:
+      summary: A channel was archived.
+      payload:
+        type: object
+        properties:
+          type:
+            type: string
+            enum: ['channel_archive']
+          channel:
+            type: string
+          user:
+            type: string
+
+    channelCreated:
+      summary: A channel was created.
+      payload:
+        type: object
+        properties:
+          type:
+            type: string
+            enum: ['channel_created']
+          channel:
+            type: object
+            properties:
+              id:
+                type: string
+              name:
+                type: string
+              created:
+                type: number
+              creator:
+                type: string
+
+    channelDeleted:
+      summary: A channel was deleted.
+      payload:
+        type: object
+        properties:
+          type:
+            type: string
+            enum: ['channel_deleted']
+          channel:
+            type: string
+
+    channelHistoryChanged:
+      summary: Bulk updates were made to a channel's history.
+      payload:
+        type: object
+        properties:
+          type:
+            type: string
+            enum: ['channel_history_changed']
+          latest:
+            type: string
+          ts:
+            type: string
+          event_ts:
+            type: string
+
+    channelJoined:
+      summary: You joined a channel.
+      payload:
+        type: object
+        properties:
+          type:
+            type: string
+            enum: ['channel_joined']
+          channel:
+            type: object
+            properties:
+              id:
+                type: string
+              name:
+                type: string
+              created:
+                type: number
+              creator:
+                type: string
+
+    channelLeft:
+      summary: You left a channel.
+      payload:
+        type: object
+        properties:
+          type:
+            type: string
+            enum: ['channel_left']
+          channel:
+            type: string
+
+    channelMarked:
+      summary: Your channel read marker was updated.
+      payload:
+        type: object
+        properties:
+          type:
+            type: string
+            enum: ['channel_marked']
+          channel:
+            type: string
+          ts:
+            type: string
+
+    channelRename:
+      summary: A channel was renamed.
+      payload:
+        type: object
+        properties:
+          type:
+            type: string
+            enum: ['channel_rename']
+          channel:
+            type: object
+            properties:
+              id:
+                type: string
+              name:
+                type: string
+              created:
+                type: number
+
+    channelUnarchive:
+      summary: A channel was unarchived.
+      payload:
+        type: object
+        properties:
+          type:
+            type: string
+            enum: ['channel_unarchive']
+          channel:
+            type: string
+          user:
+            type: string
+
+    commandsChanged:
+      summary: A slash command has been added or changed.
+      payload:
+        type: object
+        properties:
+          type:
+            type: string
+            enum: ['commands_changed']
+          event_ts:
+            type: string
+
+    dndUpdated:
+      summary: Do not Disturb settings changed for the current user.
+      payload:
+        type: object
+        properties:
+          type:
+            type: string
+            enum: ['dnd_updated']
+          user:
+            type: string
+          dnd_status:
+            type: object
+            properties:
+              dnd_enabled:
+                type: boolean
+              next_dnd_start_ts:
+                type: number
+              next_dnd_end_ts:
+                type: number
+              snooze_enabled:
+                type: boolean
+              snooze_endtime:
+                type: number
+
+    dndUpdatedUser:
+      summary: Do not Disturb settings changed for a member.
+      payload:
+        type: object
+        properties:
+          type:
+            type: string
+            enum: ['dnd_updated_user']
+          user:
+            type: string
+          dnd_status:
+            type: object
+            properties:
+              dnd_enabled:
+                type: boolean
+              next_dnd_start_ts:
+                type: number
+              next_dnd_end_ts:
+                type: number
+
+    emailDomainChanged:
+      summary: The workspace email domain has changed.
+      payload:
+        type: object
+        properties:
+          type:
+            type: string
+            enum: ['email_domain_changed']
+          email_domain:
+            type: string
+          event_ts:
+            type: string
+
+    emojiRemoved:
+      summary: A custom emoji has been removed.
+      payload:
+        type: object
+        properties:
+          type:
+            type: string
+            enum: ['emoji_changed']
+          subtype:
+            type: string
+            enum: ['remove']
+          names:
+            type: array
+            items:
+              type: string
+          event_ts:
+            type: string
+
+    emojiAdded:
+      summary: A custom emoji has been added.
+      payload:
+        type: object
+        properties:
+          type:
+            type: string
+            enum: ['emoji_changed']
+          subtype:
+            type: string
+            enum: ['add']
+          name:
+            type: string
+          value:
+            type: string
+            format: uri
+          event_ts:
+            type: string
+
+    fileChange:
+      summary: A file was changed.
+      payload:
+        type: object
+        properties:
+          type:
+            type: string
+            enum: ['file_change']
+          file_id:
+            type: string
+          file:
+            type: object
+            properties:
+              id:
+                type: string
+
+    fileCommentAdded:
+      summary: A file comment was added.
+      payload:
+        type: object
+        properties:
+          type:
+            type: string
+            enum: ['file_comment_added']
+          comment: {}
+          file_id:
+            type: string
+          file:
+            type: object
+            properties:
+              id:
+                type: string
+
+    fileCommentDeleted:
+      summary: A file comment was deleted.
+      payload:
+        type: object
+        properties:
+          type:
+            type: string
+            enum: ['file_comment_deleted']
+          comment:
+            type: string
+          file_id:
+            type: string
+          file:
+            type: object
+            properties:
+              id:
+                type: string
+
+    fileCommentEdited:
+      summary: A file comment was edited.
+      payload:
+        type: object
+        properties:
+          type:
+            type: string
+            enum: ['file_comment_edited']
+          comment: {}
+          file_id:
+            type: string
+          file:
+            type: object
+            properties:
+              id:
+                type: string
+
+    fileCreated:
+      summary: A file was created.
+      payload:
+        type: object
+        properties:
+          type:
+            type: string
+            enum: ['file_created']
+          file_id:
+            type: string
+          file:
+            type: object
+            properties:
+              id:
+                type: string
+
+    fileDeleted:
+      summary: A file was deleted.
+      payload:
+        type: object
+        properties:
+          type:
+            type: string
+            enum: ['file_deleted']
+          file_id:
+            type: string
+          event_ts:
+            type: string
+
+    filePublic:
+      summary: A file was made public.
+      payload:
+        type: object
+        properties:
+          type:
+            type: string
+            enum: ['file_public']
+          file_id:
+            type: string
+          file:
+            type: object
+            properties:
+              id:
+                type: string
+
+    fileShared:
+      summary: A file was shared.
+      payload:
+        type: object
+        properties:
+          type:
+            type: string
+            enum: ['file_shared']
+          file_id:
+            type: string
+          file:
+            type: object
+            properties:
+              id:
+                type: string
+
+    fileUnshared:
+      summary: A file was unshared.
+      payload:
+        type: object
+        properties:
+          type:
+            type: string
+            enum: ['file_unshared']
+          file_id:
+            type: string
+          file:
+            type: object
+            properties:
+              id:
+                type: string
+
+    goodbye:
+      summary: The server intends to close the connection soon.
+      payload:
+        type: object
+        properties:
+          type:
+            type: string
+            enum: ['goodbye']
+
+    groupArchive:
+      summary: A private channel was archived.
+      payload:
+        type: object
+        properties:
+          type:
+            type: string
+            enum: ['group_archive']
+          channel:
+            type: string
+
+    groupClose:
+      summary: You closed a private channel.
+      payload:
+        type: object
+        properties:
+          type:
+            type: string
+            enum: ['group_close']
+          user:
+            type: string
+          channel:
+            type: string
+
+    groupHistoryChanged:
+      summary: Bulk updates were made to a private channel's history.
+      payload:
+        type: object
+        properties:
+          type:
+            type: string
+            enum: ['group_history_changed']
+          latest:
+            type: string
+          ts:
+            type: string
+          event_ts:
+            type: string
+
+    groupJoined:
+      summary: You joined a private channel.
+      payload:
+        type: object
+        properties:
+          type:
+            type: string
+            enum: ['group_joined']
+          channel:
+            type: object
+            properties:
+              id:
+                type: string
+              name:
+                type: string
+              created:
+                type: number
+              creator:
+                type: string
+
+    groupLeft:
+      summary: You left a private channel.
+      payload:
+        type: object
+        properties:
+          type:
+            type: string
+            enum: ['group_left']
+          channel:
+            type: string
+
+    groupMarked:
+      summary: A private channel read marker was updated.
+      payload:
+        type: object
+        properties:
+          type:
+            type: string
+            enum: ['group_marked']
+          channel:
+            type: string
+          ts:
+            type: string
+
+    groupOpen:
+      summary: You opened a private channel.
+      payload:
+        type: object
+        properties:
+          type:
+            type: string
+            enum: ['group_open']
+          user:
+            type: string
+          channel:
+            type: string
+
+    groupRename:
+      summary: A private channel was renamed.
+      payload:
+        type: object
+        properties:
+          type:
+            type: string
+            enum: ['group_rename']
+          channel:
+            type: object
+            properties:
+              id:
+                type: string
+              name:
+                type: string
+              created:
+                type: number
+
+    groupUnarchive:
+      summary: A private channel was unarchived.
+      payload:
+        type: object
+        properties:
+          type:
+            type: string
+            enum: ['group_unarchive']
+          channel:
+            type: string
+          user:
+            type: string
+
+    imClose:
+      summary: You closed a DM.
+      payload:
+        type: object
+        properties:
+          type:
+            type: string
+            enum: ['im_close']
+          channel:
+            type: string
+          user:
+            type: string
+
+    imCreated:
+      summary: A DM was created.
+      payload:
+        type: object
+        properties:
+          type:
+            type: string
+            enum: ['im_created']
+          channel:
+            type: object
+            properties:
+              id:
+                type: string
+              name:
+                type: string
+              created:
+                type: number
+              creator:
+                type: string
+          user:
+            type: string
+
+    imMarked:
+      summary: A direct message read marker was updated.
+      payload:
+        type: object
+        properties:
+          type:
+            type: string
+            enum: ['im_marked']
+          channel:
+            type: string
+          ts:
+            type: string
+
+    imOpen:
+      summary: You opened a DM.
+      payload:
+        type: object
+        properties:
+          type:
+            type: string
+            enum: ['im_open']
+          channel:
+            type: string
+          user:
+            type: string
+
+    manualPresenceChange:
+      summary: You manually updated your presence.
+      payload:
+        type: object
+        properties:
+          type:
+            type: string
+            enum: ['manual_presence_change']
+          presence:
+            type: string
+
+    memberJoinedChannel:
+      summary: A user joined a public or private channel.
+      payload:
+        type: object
+        properties:
+          type:
+            type: string
+            enum: ['member_joined_channel']
+          user:
+            type: string
+          channel:
+            type: string
+          channel_type:
+            type: string
+            enum:
+              - C
+              - G
+          team:
+            type: string
+          inviter:
+            type: string
+
+    memberLeftChannel:
+      summary: A user left a public or private channel.
+      payload:
+        type: object
+        properties:
+          type:
+            type: string
+            enum: ['member_left_channel']
+          user:
+            type: string
+          channel:
+            type: string
+          channel_type:
+            type: string
+            enum:
+              - C
+              - G
+          team:
+            type: string
+
+    message:
+      summary: A message was sent to a channel.
+      payload:
+        type: object
+        properties:
+          type:
+            type: string
+            enum: ['message']
+          user:
+            type: string
+          channel:
+            type: string
+          text:
+            type: string
+          ts:
+            type: string
+          attachments:
+            type: array
+            items:
+              $ref: '#/components/schemas/attachment'
+          edited:
+            type: object
+            properties:
+              user:
+                type: string
+              ts:
+                type: string
+
+    outgoingMessage:
+      summary: A message was sent to a channel.
+      payload:
+        type: object
+        properties:
+          id:
+            type: number
+          type:
+            type: string
+            enum: ['message']
+          channel:
+            type: string
+          text:
+            type: string

--- a/examples/next/streetlights.yml
+++ b/examples/next/streetlights.yml
@@ -18,7 +18,7 @@ servers:
   - url: api.streetlights.smartylighting.com:{port}
     scheme: mqtt
     description: Test broker
-    baseTopic: smartylighting/streetlights/1/0
+    baseChannel: smartylighting/streetlights/1/0
     variables:
       port:
         description: Secure connection (TLS) is available through port 8883.
@@ -35,7 +35,7 @@ security:
     - streetlights:dim
   - openIdConnectWellKnown: []
 
-topics:
+channels:
   event/{streetlightId}/lighting/measured:
     parameters:
       - $ref: '#/components/parameters/streetlightId'

--- a/versions/next/asyncapi.md
+++ b/versions/next/asyncapi.md
@@ -25,7 +25,7 @@ user/signedup:
     $ref: "#/components/messages/userSignUp"
 ```
 
-It means [processes](#definitionsProcess) can subscribe to `user/signedup` topic. However, it does NOT mean every [process](#definitionsProcess) must subscribe to this topic.
+It means [processes](#definitionsProcess) can subscribe to `user/signedup` channel. However, it does NOT mean every [process](#definitionsProcess) must subscribe to this channel.
 
 ## Table of Contents
 <!-- TOC depthFrom:2 depthTo:4 withLinks:1 updateOnSave:0 orderedList:0 -->
@@ -33,7 +33,7 @@ It means [processes](#definitionsProcess) can subscribe to `user/signedup` topic
 - [Definitions](#definitions)
 	- [Message Broker](#definitionsMessageBroker)
 	- [Message](#definitionsMessage)
-	- [Topic](#definitionstTopic)
+	- [Channel](#definitionstChannel)
 	- [Process](#definitionsProcess)
 	- [Producer](#definitionsProducer)
 	- [Consumer](#definitionsConsumer)
@@ -47,10 +47,9 @@ It means [processes](#definitionsProcess) can subscribe to `user/signedup` topic
 		- [Contact Object](#contactObject)
 		- [License Object](#licenseObject)
 		- [Servers Object](#A2SServers)
-		- [Topics Object](#topicsObject)
-		- [Topic Item Object](#topicItemObject)
+		- [Channels Object](#channelsObject)
+		- [Channel Item Object](#channelItemObject)
 		- [Stream Object](#streamObject)
-		- [Events Object](#eventsObject)
 		- [Message Object](#messageObject)
 		- [Tag Object](#tagObject)
 		- [External Documentation Object](#externalDocumentationObject)
@@ -72,8 +71,8 @@ A message broker is a system in charge of message exchange. It MAY provide addit
 #### <a name="definitionsMessage"></a>Message
 A message is a piece of information a process will send to a message broker. It MUST contain headers and payload.
 
-#### <a name="definitionstTopic"></a>Topic
-A topic is a routing key used by the message broker to deliver messages to the subscribed processes. Depending on the protocol used, a message MAY include the topic in its headers.
+#### <a name="definitionstChannel"></a>Channel
+A channel is a routing key used by the message broker to deliver messages to the subscribed processes. Depending on the protocol used, a message MAY include the channel in its headers.
 
 #### <a name="definitionsProcess"></a>Process
 A process is any kind of computer program connected to a message broker. It MUST be a producer, a consumer or both.
@@ -134,9 +133,8 @@ Field Name | Type | Description
 <a name="A2SAsyncAPI"></a>asyncapi | [AsyncAPI Version String](#A2SVersionString) | **Required.** Specifies the AsyncAPI Specification version being used. It can be used by tooling Specifications and clients to interpret the version. The structure shall be `major`.`minor`.`patch`, where `patch` versions _must_ be compatible with the existing `major`.`minor` tooling. Typically patch versions will be introduced to address errors in the documentation, and tooling should typically be compatible with the corresponding `major`.`minor` (1.0.*). Patch versions will correspond to patches of this document.
 <a name="A2SInfo"></a>info | [Info Object](#infoObject) | **Required.** Provides metadata about the API. The metadata can be used by the clients if needed.
 <a name="A2SServers"></a>servers | [Server Object](#serverObject) | An array of [Server Objects](#serverObject), which provide connectivity information to a target server.
-<a name="A2STopics"></a>topics | [Topics Object](#topicsObject) | **Required unless [Stream Object](#streamObject) or [Events Object](#eventsObject) is provided.** The available topics and messages for the API.
-<a name="A2SStream"></a>stream | [Stream Object](#streamObject) | **Required unless [Topics Object](#topicsObject) or [Events Object](#eventsObject) is provided.** The messages and configuration for the streaming API.
-<a name="A2SEvents"></a>events | [Events Object](#eventsObject) | **Required unless [Topics Object](#topicsObject) or [Stream Object](#streamObject) is provided.** The messages and configuration for the events API.
+<a name="A2SChannels"></a>channels | [Channels Object](#channelsObject) | **Required unless [Stream Object](#streamObject) is provided.** The available channels and messages for the API.
+<a name="A2SStream"></a>stream | [Stream Object](#streamObject) | **Required unless [Channels Object](#channelsObject) is provided.** The messages and configuration for the streaming API.
 <a name="A2SComponents"></a>components | [Components Object](#componentsObject) | An element to hold various schemas for the specification.
 <a name="A2SSecurity"></a>security | [[Security Requirement Object](#securityRequirementObject)] | A declaration of which security mechanisms can be used across the API. The list of values includes alternative security requirement objects that can be used. Only one of the security requirement objects need to be satisfied to authorize a connection or operation.
 <a name="A2STags"></a>tags | [[Tag Object](#tagObject)] | A list of tags used by the specification with additional metadata. Each tag name in the list MUST be unique.
@@ -279,7 +277,7 @@ Field Name | Type | Description
 <a name="serverObjectSchemeVersion"></a>schemeVersion | `string` | The version of the scheme. For instance: AMQP `0.9.1`, Kafka `1.0.0`, etc.
 <a name="serverObjectDescription"></a>description | `string` | An optional string describing the host designated by the URL. [CommonMark syntax](http://spec.commonmark.org/) MAY be used for rich text representation.
 <a name="serverObjectVariables"></a>variables | Map[`string`, [Server Variable Object](#serverVariableObject)] | A map between a variable name and its value.  The value is used for substitution in the server's URL template.
-<a name="serverObjectBaseTopic"></a>baseTopic | `string` | A string describing the base topic. MUST be in the form of a [RFC 3986 URI path](https://tools.ietf.org/html/rfc3986#section-3.3). URI templates are not allowed here. Defaults to empty string.
+<a name="serverObjectBaseChannel"></a>baseChannel | `string` | A string describing the base channel. MUST be in the form of a [RFC 3986 URI path](https://tools.ietf.org/html/rfc3986#section-3.3). URI templates are not allowed here. Defaults to empty string.
 
 This object MAY be extended with [Specification Extensions](#specificationExtensions).
 
@@ -293,7 +291,7 @@ A single server would be described as:
   "description": "Development server",
   "scheme": "kafka",
   "schemeVersion": "1.0.0",
-  "baseTopic": "company/events"
+  "baseChannel": "company/events"
 }
 ```
 
@@ -302,7 +300,7 @@ url: development.gigantic-server.com
 description: Development server
 scheme: kafka
 schemeVersion: '1.0.0'
-baseTopic: company/events
+baseChannel: company/events
 ```
 
 The following shows how multiple servers can be described, for example, at the AsyncAPI Object's [`servers`](#A2SServers):
@@ -417,20 +415,20 @@ This object MAY be extended with [Specification Extensions](#specificationExtens
 
 
 
-#### <a name="topicsObject"></a>Topics Object
+#### <a name="channelsObject"></a>Channels Object
 
-Holds the relative paths to the individual topic and their operations.
-Topics starting with a slash (`/`) MUST be treated as absolute paths and therefore skipping the [`server's base topic`](#serverObjectBaseTopic). Otherwise, the final topic MUST be resolved using the [`server's base topic`](#serverObjectBaseTopic) and the current path.
+Holds the relative paths to the individual channel and their operations.
+Channels starting with a slash (`/`) MUST be treated as absolute paths and therefore skipping the [`server's base channel`](#serverObjectBaseChannel). Otherwise, the final channel MUST be resolved using the [`server's base channel`](#serverObjectBaseChannel) and the current path.
 
 ##### Patterned Fields
 
 Field Pattern | Type | Description
 ---|:---:|---
-<a name="topicsObjectTopic"></a>{topic} | [Topic Item Object](#topicItemObject) | A relative path to an individual topic. The field name MUST be in the form of a [RFC 6570 URI template](https://tools.ietf.org/html/rfc6570).
+<a name="channelsObjectChannel"></a>{channel} | [Channel Item Object](#channelItemObject) | A relative path to an individual channel. The field name MUST be in the form of a [RFC 6570 URI template](https://tools.ietf.org/html/rfc6570).
 
 This object can be extended with [Specification Extensions](#specificationExtensions).
 
-##### Topics Object Example
+##### Channels Object Example
 
 ```json
 {
@@ -451,22 +449,22 @@ user/signedup:
 
 
 
-#### <a name="topicItemObject"></a>Topic Item Object
+#### <a name="channelItemObject"></a>Channel Item Object
 
-Describes the operations available on a single topic.
+Describes the operations available on a single channel.
 
 ##### Fixed Fields
 
 Field Name | Type | Description
 ---|:---:|---
-<a name="topicItemObjectRef"></a>$ref | `string` | Allows for an external definition of this topic item. The referenced structure MUST be in the format of a [Topic Item Object](#topicItemObject). If there are conflicts between the referenced definition and this Topic Item's definition, the behavior is *undefined*.
-<a name="topicItemObjectSubscribe"></a>subscribe | [Message Object](#messageObject) &#124; Map[`"oneOf"`, [[Message Object](#messageObject)]] | A definition of the message a SUBSCRIBE operation will receive on this topic. `oneOf` is allowed here to specify multiple messages, however, **a message MUST be valid only against one of the referenced message objects.**
-<a name="topicItemObjectPublish"></a>publish | [Message Object](#messageObject) &#124; Map[`"oneOf"`, [[Message Object](#messageObject)]] | A definition of the message a PUBLISH operation will receive on this topic. `oneOf` is allowed here to specify multiple messages, however, **a message MUST be valid only against one of the referenced message objects.**
-<a name="topicItemObjectParameters"></a>parameters | [[Parameter Object](#parameterObject) &#124; [Reference Object](#referenceObject)] | A list of the parameters included in the topic name. It SHOULD be present only when using topics with expressions (as defined by [RFC 6570 section 2.2](https://tools.ietf.org/html/rfc6570#section-2.2)).
+<a name="channelItemObjectRef"></a>$ref | `string` | Allows for an external definition of this channel item. The referenced structure MUST be in the format of a [Channel Item Object](#channelItemObject). If there are conflicts between the referenced definition and this Channel Item's definition, the behavior is *undefined*.
+<a name="channelItemObjectSubscribe"></a>subscribe | [Message Object](#messageObject) &#124; Map[`"oneOf"`, [[Message Object](#messageObject)]] | A definition of the message a SUBSCRIBE operation will receive on this channel. `oneOf` is allowed here to specify multiple messages, however, **a message MUST be valid only against one of the referenced message objects.**
+<a name="channelItemObjectPublish"></a>publish | [Message Object](#messageObject) &#124; Map[`"oneOf"`, [[Message Object](#messageObject)]] | A definition of the message a PUBLISH operation will receive on this channel. `oneOf` is allowed here to specify multiple messages, however, **a message MUST be valid only against one of the referenced message objects.**
+<a name="channelItemObjectParameters"></a>parameters | [[Parameter Object](#parameterObject) &#124; [Reference Object](#referenceObject)] | A list of the parameters included in the channel name. It SHOULD be present only when using channels with expressions (as defined by [RFC 6570 section 2.2](https://tools.ietf.org/html/rfc6570#section-2.2)).
 
 This object can be extended with [Specification Extensions](#specificationExtensions).
 
-##### Topic Item Object Example
+##### Channel Item Object Example
 
 ```json
 {
@@ -529,7 +527,7 @@ subscribe:
 
 #### <a name="parameterObject"></a>Parameter Object
 
-Describes a parameter included in a topic name.
+Describes a parameter included in a channel name.
 
 ##### Fixed Fields
 
@@ -662,50 +660,9 @@ framing:
 
 
 
-#### <a name="eventsObject"></a>Events Object
-
-Holds the send and receive operations for an API based on events but without topics, e.g., a WebSockets API.
-
-##### Fixed Fields
-
-Field Name | Type | Description
----|:---:|---
-<a name="eventsObjectRead"></a>receive | [[Message Object](#messageObject)] | A list of messages a consumer can receive from the API.
-<a name="eventsObjectWrite"></a>send | [[Message Object](#messageObject)] | A list of messages a consumer can send to the API.
-
-Either `receive` or `send` MUST be provided.
-
-This object can be extended with [Specification Extensions](#specificationExtensions).
-
-##### Events Object Example
-
-```json
-{
-  "events": {
-    "receive": [
-      { "$ref": "#/components/messages/chatMessage" },
-      { "$ref": "#/components/messages/heartbeat" }
-    ]
-  }
-}
-```
-
-```yaml
-events:
-  receive:
-    - $ref: '#/components/messages/chatMessage'
-    - $ref: '#/components/messages/heartbeat'
-```
-
-
-
-
-
-
-
 #### <a name="messageObject"></a>Message Object
 
-Describes a message received on a given topic and operation.
+Describes a message received on a given channel and operation.
 
 ##### Fixed Fields
 

--- a/versions/next/schema.json
+++ b/versions/next/schema.json
@@ -1,5 +1,5 @@
 {
-  "title": "AsyncAPI 1.2.0 schema.",
+  "title": "AsyncAPI 2.0.0 schema.",
   "$schema": "http://json-schema.org/draft-07/schema#",
   "type": "object",
   "required": [
@@ -9,17 +9,12 @@
   "oneOf": [
     {
       "required": [
-        "topics"
+        "channels"
       ]
     },
     {
       "required": [
         "stream"
-      ]
-    },
-    {
-      "required": [
-        "events"
       ]
     }
   ],
@@ -47,16 +42,12 @@
       },
       "uniqueItems": true
     },
-    "topics": {
-      "$ref": "#/definitions/topics"
+    "channels": {
+      "$ref": "#/definitions/channels"
     },
     "stream": {
       "$ref": "#/definitions/stream",
       "description": "The list of messages a consumer can read or write from/to a streaming API."
-    },
-    "events": {
-      "$ref": "#/definitions/events",
-      "description": "The list of messages an events API sends and/or receives."
     },
     "components": {
       "$ref": "#/definitions/components"
@@ -225,7 +216,7 @@
         "variables": {
           "$ref": "#/definitions/serverVariables"
         },
-        "baseTopic": {
+        "baseChannel": {
           "type": "string",
           "x-format": "uri-path"
         }
@@ -263,9 +254,8 @@
         }
       }
     },
-    "topics": {
+    "channels": {
       "type": "object",
-      "description": "Relative paths to the individual topics. They must be relative to the 'baseTopic'.",
       "propertyNames": {
         "type": "string",
         "format": "uri-template",
@@ -273,7 +263,7 @@
       },
       "patternProperties": {
         "": {
-          "$ref": "#/definitions/topicItem"
+          "$ref": "#/definitions/channelItem"
         }
       }
     },
@@ -323,7 +313,7 @@
       "additionalProperties": {
         "$ref": "#/definitions/parameter"
       },
-      "description": "JSON objects describing re-usable topic parameters."
+      "description": "JSON objects describing re-usable channel parameters."
     },
     "schema": {
       "type": "object",
@@ -520,7 +510,7 @@
         }
       }
     },
-    "topicItem": {
+    "channelItem": {
       "type": "object",
       "additionalProperties": false,
       "patternProperties": {
@@ -672,49 +662,6 @@
         },
         "write": {
           "title": "Stream Write Object",
-          "type": "array",
-          "uniqueItems": true,
-          "minItems": 1,
-          "items": {
-            "$ref": "#/definitions/message"
-          }
-        }
-      }
-    },
-    "events": {
-      "title": "Events Object",
-      "type": "object",
-      "additionalProperties": false,
-      "patternProperties": {
-        "^x-": {
-          "$ref": "#/definitions/vendorExtension"
-        }
-      },
-      "minProperties": 1,
-      "anyOf": [
-        {
-          "required": [
-            "receive"
-          ]
-        },
-        {
-          "required": [
-            "send"
-          ]
-        }
-      ],
-      "properties": {
-        "receive": {
-          "title": "Events Receive Object",
-          "type": "array",
-          "uniqueItems": true,
-          "minItems": 1,
-          "items": {
-            "$ref": "#/definitions/message"
-          }
-        },
-        "send": {
-          "title": "Events Send Object",
           "type": "array",
           "uniqueItems": true,
           "minItems": 1,


### PR DESCRIPTION
### What?
Fixes #110 and fixes #111.

It just renames `topics` as `channels` and removes `events`.

### Why?
* Channels is a much broader term, not tied to specific technologies.
* Since channels are URIs (see #124), the root channel (`/`) will act as a "no channel" or "global channel".