### PR TITLE
Remove mqtts from the list of supported schemes

### DIFF
--- a/versions/next/schema.json
+++ b/versions/next/schema.json
@@ -199,7 +199,6 @@
             "amqp",
             "amqps",
             "mqtt",
-            "mqtts",
             "secure-mqtt",
             "ws",
             "wss",


### PR DESCRIPTION
### What?
Fixes #46 

Removes mqtts in favor of secure-mqtt, which is the right IANA id for the protocol.

### Why?
See #46 for more details.