### PR TITLE
Remove scheme restrictions

### DIFF
--- a/versions/next/asyncapi.md
+++ b/versions/next/asyncapi.md
@@ -273,7 +273,7 @@ An object representing a Server.
 Field Name | Type | Description
 ---|:---:|---
 <a name="serverObjectUrl"></a>url | `string` | **REQUIRED**. A URL to the target host.  This URL supports Server Variables and MAY be relative, to indicate that the host location is relative to the location where the AsyncAPI document is being served. Variable substitutions will be made when a variable is named in `{`brackets`}`.
-<a name="serverObjectScheme"></a>scheme | `string` | **REQUIRED**. The scheme this URL supports for connection. The value MUST be one of the following: `kafka`, `kafka-secure`, `amqp`, `amqps`, `mqtt`, `secure-mqtt`, `ws`, `wss`, `stomp`, `stomps`, `jms`.
+<a name="serverObjectScheme"></a>scheme | `string` | **REQUIRED**. The scheme this URL supports for connection. Supported schemes include, but are not limited to: `kafka`, `kafka-secure`, `amqp`, `amqps`, `mqtt`, `secure-mqtt`, `ws`, `wss`, `stomp`, `stomps`, `jms`.
 <a name="serverObjectSchemeVersion"></a>schemeVersion | `string` | The version of the scheme. For instance: AMQP `0.9.1`, Kafka `1.0.0`, etc.
 <a name="serverObjectDescription"></a>description | `string` | An optional string describing the host designated by the URL. [CommonMark syntax](http://spec.commonmark.org/) MAY be used for rich text representation.
 <a name="serverObjectVariables"></a>variables | Map[`string`, [Server Variable Object](#serverVariableObject)] | A map between a variable name and its value.  The value is used for substitution in the server's URL template.

--- a/versions/next/schema.json
+++ b/versions/next/schema.json
@@ -192,23 +192,7 @@
         },
         "scheme": {
           "type": "string",
-          "description": "The transfer protocol.",
-          "enum": [
-            "kafka",
-            "kafka-secure",
-            "amqp",
-            "amqps",
-            "mqtt",
-            "mqtts",
-            "secure-mqtt",
-            "ws",
-            "wss",
-            "stomp",
-            "stomps",
-            "jms",
-            "http",
-            "https"
-          ]
+          "description": "The transfer protocol."
         },
         "schemeVersion": {
           "type": "string"


### PR DESCRIPTION
### What?
Fixes #91 

Removes the restriction on the `scheme` field, allowing it to contain any string value.

### Why?
After thinking a lot, I came to the conclusion that restrictions on this field were just causing the tooling to evolve more slowly, and proposed solutions were just making it more complicated for the tools to validate.

We can keep a list of suggested values and make sure the tools follow them. In case this goes wild, nothing stops us from putting the restriction back.