### PR TITLE
Separate operation from message and change schema format definition mechanism

### DIFF
--- a/examples/next/anyof.yml
+++ b/examples/next/anyof.yml
@@ -6,16 +6,16 @@ info:
 channels:
   test:
     publish:
-      $ref: '#/components/messages/testMessages'
+      message:
+        $ref: '#/components/messages/testMessages'
 
 components:
   messages:
     testMessages:
       payload:
-        'application/schema+json;version=draft-07':
-          anyOf: # anyOf in payload schema
-            - $ref: "#/components/schemas/objectWithKey"
-            - $ref: "#/components/schemas/objectWithKey2"
+        anyOf: # anyOf in payload schema
+          - $ref: "#/components/schemas/objectWithKey"
+          - $ref: "#/components/schemas/objectWithKey2"
 
   schemas:
     objectWithKey:

--- a/examples/next/not.yml
+++ b/examples/next/not.yml
@@ -6,14 +6,14 @@ info:
 channels:
   test:
     publish:
-      $ref: '#/components/messages/testMessages'
+      message:
+        $ref: '#/components/messages/testMessages'
 
 components:
   messages:
     testMessages:
       payload:
-        'application/schema+json;version=draft-07':
-          $ref: "#/components/schemas/testSchema"
+        $ref: "#/components/schemas/testSchema"
 
   schemas:
     testSchema:

--- a/examples/next/oneof.yml
+++ b/examples/next/oneof.yml
@@ -6,35 +6,32 @@ info:
 channels:
   test:
     publish:
-      $ref: '#/components/messages/testMessages'
+      message:
+        $ref: '#/components/messages/testMessages'
 
   test2:
     subscribe:
-      # Use oneOf here if different messages are published on test2 topic.
-      oneOf:
-        - payload:
-            'application/schema+json;version=draft-07':
+      message:
+        # Use oneOf here if different messages are published on test2 topic.
+        oneOf:
+          - payload:
               $ref: "#/components/schemas/objectWithKey"
-        - payload:
-            'application/schema+json;version=draft-07':
+          - payload:
               $ref: "#/components/schemas/objectWithKey2"
 
 components:
   messages:
     testMessages:
       payload:
-        'application/schema+json;version=draft-07':
-          oneOf: # oneOf in payload schema
-            - $ref: "#/components/schemas/objectWithKey"
-            - $ref: "#/components/schemas/objectWithKey2"
+        oneOf: # oneOf in payload schema
+          - $ref: "#/components/schemas/objectWithKey"
+          - $ref: "#/components/schemas/objectWithKey2"
     testMessage1:
       payload:
-        'application/schema+json;version=draft-07':
-          $ref: "#/components/schemas/objectWithKey"
+        $ref: "#/components/schemas/objectWithKey"
     testMessage2:
       payload:
-        'application/schema+json;version=draft-07':
-          $ref: "#/components/schemas/objectWithKey2"
+        $ref: "#/components/schemas/objectWithKey2"
 
   schemas:
     objectWithKey:

--- a/examples/next/slack-rtm.yml
+++ b/examples/next/slack-rtm.yml
@@ -13,55 +13,57 @@ servers:
 channels:
   /:
     subscribe:
-      oneOf:
-        - $ref: '#/components/messages/hello'
-        - $ref: '#/components/messages/connectionError'
-        - $ref: '#/components/messages/accountsChanged'
-        - $ref: '#/components/messages/botAdded'
-        - $ref: '#/components/messages/botChanged'
-        - $ref: '#/components/messages/channelArchive'
-        - $ref: '#/components/messages/channelCreated'
-        - $ref: '#/components/messages/channelDeleted'
-        - $ref: '#/components/messages/channelHistoryChanged'
-        - $ref: '#/components/messages/channelJoined'
-        - $ref: '#/components/messages/channelLeft'
-        - $ref: '#/components/messages/channelMarked'
-        - $ref: '#/components/messages/channelRename'
-        - $ref: '#/components/messages/channelUnarchive'
-        - $ref: '#/components/messages/commandsChanged'
-        - $ref: '#/components/messages/dndUpdated'
-        - $ref: '#/components/messages/dndUpdatedUser'
-        - $ref: '#/components/messages/emailDomainChanged'
-        - $ref: '#/components/messages/emojiRemoved'
-        - $ref: '#/components/messages/emojiAdded'
-        - $ref: '#/components/messages/fileChange'
-        - $ref: '#/components/messages/fileCommentAdded'
-        - $ref: '#/components/messages/fileCommentDeleted'
-        - $ref: '#/components/messages/fileCommentEdited'
-        - $ref: '#/components/messages/fileCreated'
-        - $ref: '#/components/messages/fileDeleted'
-        - $ref: '#/components/messages/filePublic'
-        - $ref: '#/components/messages/fileShared'
-        - $ref: '#/components/messages/fileUnshared'
-        - $ref: '#/components/messages/goodbye'
-        - $ref: '#/components/messages/groupArchive'
-        - $ref: '#/components/messages/groupClose'
-        - $ref: '#/components/messages/groupHistoryChanged'
-        - $ref: '#/components/messages/groupJoined'
-        - $ref: '#/components/messages/groupLeft'
-        - $ref: '#/components/messages/groupMarked'
-        - $ref: '#/components/messages/groupOpen'
-        - $ref: '#/components/messages/groupRename'
-        - $ref: '#/components/messages/groupUnarchive'
-        - $ref: '#/components/messages/imClose'
-        - $ref: '#/components/messages/imCreated'
-        - $ref: '#/components/messages/imMarked'
-        - $ref: '#/components/messages/imOpen'
-        - $ref: '#/components/messages/manualPresenceChange'
-        - $ref: '#/components/messages/memberJoinedChannel'
-        - $ref: '#/components/messages/message'
+      message:
+        oneOf:
+          - $ref: '#/components/messages/hello'
+          - $ref: '#/components/messages/connectionError'
+          - $ref: '#/components/messages/accountsChanged'
+          - $ref: '#/components/messages/botAdded'
+          - $ref: '#/components/messages/botChanged'
+          - $ref: '#/components/messages/channelArchive'
+          - $ref: '#/components/messages/channelCreated'
+          - $ref: '#/components/messages/channelDeleted'
+          - $ref: '#/components/messages/channelHistoryChanged'
+          - $ref: '#/components/messages/channelJoined'
+          - $ref: '#/components/messages/channelLeft'
+          - $ref: '#/components/messages/channelMarked'
+          - $ref: '#/components/messages/channelRename'
+          - $ref: '#/components/messages/channelUnarchive'
+          - $ref: '#/components/messages/commandsChanged'
+          - $ref: '#/components/messages/dndUpdated'
+          - $ref: '#/components/messages/dndUpdatedUser'
+          - $ref: '#/components/messages/emailDomainChanged'
+          - $ref: '#/components/messages/emojiRemoved'
+          - $ref: '#/components/messages/emojiAdded'
+          - $ref: '#/components/messages/fileChange'
+          - $ref: '#/components/messages/fileCommentAdded'
+          - $ref: '#/components/messages/fileCommentDeleted'
+          - $ref: '#/components/messages/fileCommentEdited'
+          - $ref: '#/components/messages/fileCreated'
+          - $ref: '#/components/messages/fileDeleted'
+          - $ref: '#/components/messages/filePublic'
+          - $ref: '#/components/messages/fileShared'
+          - $ref: '#/components/messages/fileUnshared'
+          - $ref: '#/components/messages/goodbye'
+          - $ref: '#/components/messages/groupArchive'
+          - $ref: '#/components/messages/groupClose'
+          - $ref: '#/components/messages/groupHistoryChanged'
+          - $ref: '#/components/messages/groupJoined'
+          - $ref: '#/components/messages/groupLeft'
+          - $ref: '#/components/messages/groupMarked'
+          - $ref: '#/components/messages/groupOpen'
+          - $ref: '#/components/messages/groupRename'
+          - $ref: '#/components/messages/groupUnarchive'
+          - $ref: '#/components/messages/imClose'
+          - $ref: '#/components/messages/imCreated'
+          - $ref: '#/components/messages/imMarked'
+          - $ref: '#/components/messages/imOpen'
+          - $ref: '#/components/messages/manualPresenceChange'
+          - $ref: '#/components/messages/memberJoinedChannel'
+          - $ref: '#/components/messages/message'
     publish:
-      $ref: '#/components/messages/outgoingMessage'
+      message:
+        $ref: '#/components/messages/outgoingMessage'
 
 components:
   securitySchemes:
@@ -122,804 +124,759 @@ components:
 
   messages:
     hello:
-      summary: First event received upon connection.
+      summary: 'First event received upon connection.'
       payload:
-        'application/schema+json;version=draft-07':
-          type: object
-          properties:
-            type:
-              type: string
-              enum: ['hello']
-
+        type: object
+        properties:
+          type:
+            type: string
+            enum:
+              - hello
     connectionError:
-      summary: Event received when a connection error happens.
+      summary: 'Event received when a connection error happens.'
       payload:
-        'application/schema+json;version=draft-07':
-          type: object
-          properties:
-            type:
-              type: string
-              enum: ['error']
-            error:
-              type: object
-              properties:
-                code:
-                  type: number
-                msg:
-                  type: string
-
-    accountsChanged:
-      summary: The list of accounts a user is signed into has changed.
-      payload:
-        'application/schema+json;version=draft-07':
-          type: object
-          properties:
-            type:
-              type: string
-              enum: ['accounts_changed']
-
-    botAdded:
-      summary: A bot user was added.
-      payload:
-        'application/schema+json;version=draft-07':
-          type: object
-          properties:
-            type:
-              type: string
-              enum: ['bot_added']
-            bot:
-              type: object
-              properties:
-                id:
-                  type: string
-                app_id:
-                  type: string
-                name:
-                  type: string
-                icons:
-                  type: object
-                  additionalProperties:
-                    type: string
-
-    botChanged:
-      summary: A bot user was changed.
-      payload:
-        'application/schema+json;version=draft-07':
-          type: object
-          properties:
-            type:
-              type: string
-              enum: ['bot_added']
-            bot:
-              type: object
-              properties:
-                id:
-                  type: string
-                app_id:
-                  type: string
-                name:
-                  type: string
-                icons:
-                  type: object
-                  additionalProperties:
-                    type: string
-
-    channelArchive:
-      summary: A channel was archived.
-      payload:
-        'application/schema+json;version=draft-07':
-          type: object
-          properties:
-            type:
-              type: string
-              enum: ['channel_archive']
-            channel:
-              type: string
-            user:
-              type: string
-
-    channelCreated:
-      summary: A channel was created.
-      payload:
-        'application/schema+json;version=draft-07':
-          type: object
-          properties:
-            type:
-              type: string
-              enum: ['channel_created']
-            channel:
-              type: object
-              properties:
-                id:
-                  type: string
-                name:
-                  type: string
-                created:
-                  type: number
-                creator:
-                  type: string
-
-    channelDeleted:
-      summary: A channel was deleted.
-      payload:
-        'application/schema+json;version=draft-07':
-          type: object
-          properties:
-            type:
-              type: string
-              enum: ['channel_deleted']
-            channel:
-              type: string
-
-    channelHistoryChanged:
-      summary: Bulk updates were made to a channel's history.
-      payload:
-        'application/schema+json;version=draft-07':
-          type: object
-          properties:
-            type:
-              type: string
-              enum: ['channel_history_changed']
-            latest:
-              type: string
-            ts:
-              type: string
-            event_ts:
-              type: string
-
-    channelJoined:
-      summary: You joined a channel.
-      payload:
-        'application/schema+json;version=draft-07':
-          type: object
-          properties:
-            type:
-              type: string
-              enum: ['channel_joined']
-            channel:
-              type: object
-              properties:
-                id:
-                  type: string
-                name:
-                  type: string
-                created:
-                  type: number
-                creator:
-                  type: string
-
-    channelLeft:
-      summary: You left a channel.
-      payload:
-        'application/schema+json;version=draft-07':
-          type: object
-          properties:
-            type:
-              type: string
-              enum: ['channel_left']
-            channel:
-              type: string
-
-    channelMarked:
-      summary: Your channel read marker was updated.
-      payload:
-        'application/schema+json;version=draft-07':
-          type: object
-          properties:
-            type:
-              type: string
-              enum: ['channel_marked']
-            channel:
-              type: string
-            ts:
-              type: string
-
-    channelRename:
-      summary: A channel was renamed.
-      payload:
-        'application/schema+json;version=draft-07':
-          type: object
-          properties:
-            type:
-              type: string
-              enum: ['channel_rename']
-            channel:
-              type: object
-              properties:
-                id:
-                  type: string
-                name:
-                  type: string
-                created:
-                  type: number
-
-    channelUnarchive:
-      summary: A channel was unarchived.
-      payload:
-        'application/schema+json;version=draft-07':
-          type: object
-          properties:
-            type:
-              type: string
-              enum: ['channel_unarchive']
-            channel:
-              type: string
-            user:
-              type: string
-
-    commandsChanged:
-      summary: A slash command has been added or changed.
-      payload:
-        'application/schema+json;version=draft-07':
-          type: object
-          properties:
-            type:
-              type: string
-              enum: ['commands_changed']
-            event_ts:
-              type: string
-
-    dndUpdated:
-      summary: Do not Disturb settings changed for the current user.
-      payload:
-        'application/schema+json;version=draft-07':
-          type: object
-          properties:
-            type:
-              type: string
-              enum: ['dnd_updated']
-            user:
-              type: string
-            dnd_status:
-              type: object
-              properties:
-                dnd_enabled:
-                  type: boolean
-                next_dnd_start_ts:
-                  type: number
-                next_dnd_end_ts:
-                  type: number
-                snooze_enabled:
-                  type: boolean
-                snooze_endtime:
-                  type: number
-
-    dndUpdatedUser:
-      summary: Do not Disturb settings changed for a member.
-      payload:
-        'application/schema+json;version=draft-07':
-          type: object
-          properties:
-            type:
-              type: string
-              enum: ['dnd_updated_user']
-            user:
-              type: string
-            dnd_status:
-              type: object
-              properties:
-                dnd_enabled:
-                  type: boolean
-                next_dnd_start_ts:
-                  type: number
-                next_dnd_end_ts:
-                  type: number
-
-    emailDomainChanged:
-      summary: The workspace email domain has changed.
-      payload:
-        'application/schema+json;version=draft-07':
-          type: object
-          properties:
-            type:
-              type: string
-              enum: ['email_domain_changed']
-            email_domain:
-              type: string
-            event_ts:
-              type: string
-
-    emojiRemoved:
-      summary: A custom emoji has been removed.
-      payload:
-        'application/schema+json;version=draft-07':
-          type: object
-          properties:
-            type:
-              type: string
-              enum: ['emoji_changed']
-            subtype:
-              type: string
-              enum: ['remove']
-            names:
-              type: array
-              items:
+        type: object
+        properties:
+          type:
+            type: string
+            enum:
+              - error
+          error:
+            type: object
+            properties:
+              code:
+                type: number
+              msg:
                 type: string
-            event_ts:
+    accountsChanged:
+      summary: 'The list of accounts a user is signed into has changed.'
+      payload:
+        type: object
+        properties:
+          type:
+            type: string
+            enum:
+              - accounts_changed
+    botAdded:
+      summary: 'A bot user was added.'
+      payload:
+        type: object
+        properties:
+          type:
+            type: string
+            enum:
+              - bot_added
+          bot:
+            type: object
+            properties:
+              id:
+                type: string
+              app_id:
+                type: string
+              name:
+                type: string
+              icons:
+                type: object
+                additionalProperties:
+                  type: string
+    botChanged:
+      summary: 'A bot user was changed.'
+      payload:
+        type: object
+        properties:
+          type:
+            type: string
+            enum:
+              - bot_added
+          bot:
+            type: object
+            properties:
+              id:
+                type: string
+              app_id:
+                type: string
+              name:
+                type: string
+              icons:
+                type: object
+                additionalProperties:
+                  type: string
+    channelArchive:
+      summary: 'A channel was archived.'
+      payload:
+        type: object
+        properties:
+          type:
+            type: string
+            enum:
+              - channel_archive
+          channel:
+            type: string
+          user:
+            type: string
+    channelCreated:
+      summary: 'A channel was created.'
+      payload:
+        type: object
+        properties:
+          type:
+            type: string
+            enum:
+              - channel_created
+          channel:
+            type: object
+            properties:
+              id:
+                type: string
+              name:
+                type: string
+              created:
+                type: number
+              creator:
+                type: string
+    channelDeleted:
+      summary: 'A channel was deleted.'
+      payload:
+        type: object
+        properties:
+          type:
+            type: string
+            enum:
+              - channel_deleted
+          channel:
+            type: string
+    channelHistoryChanged:
+      summary: 'Bulk updates were made to a channel''s history.'
+      payload:
+        type: object
+        properties:
+          type:
+            type: string
+            enum:
+              - channel_history_changed
+          latest:
+            type: string
+          ts:
+            type: string
+          event_ts:
+            type: string
+    channelJoined:
+      summary: 'You joined a channel.'
+      payload:
+        type: object
+        properties:
+          type:
+            type: string
+            enum:
+              - channel_joined
+          channel:
+            type: object
+            properties:
+              id:
+                type: string
+              name:
+                type: string
+              created:
+                type: number
+              creator:
+                type: string
+    channelLeft:
+      summary: 'You left a channel.'
+      payload:
+        type: object
+        properties:
+          type:
+            type: string
+            enum:
+              - channel_left
+          channel:
+            type: string
+    channelMarked:
+      summary: 'Your channel read marker was updated.'
+      payload:
+        type: object
+        properties:
+          type:
+            type: string
+            enum:
+              - channel_marked
+          channel:
+            type: string
+          ts:
+            type: string
+    channelRename:
+      summary: 'A channel was renamed.'
+      payload:
+        type: object
+        properties:
+          type:
+            type: string
+            enum:
+              - channel_rename
+          channel:
+            type: object
+            properties:
+              id:
+                type: string
+              name:
+                type: string
+              created:
+                type: number
+    channelUnarchive:
+      summary: 'A channel was unarchived.'
+      payload:
+        type: object
+        properties:
+          type:
+            type: string
+            enum:
+              - channel_unarchive
+          channel:
+            type: string
+          user:
+            type: string
+    commandsChanged:
+      summary: 'A slash command has been added or changed.'
+      payload:
+        type: object
+        properties:
+          type:
+            type: string
+            enum:
+              - commands_changed
+          event_ts:
+            type: string
+    dndUpdated:
+      summary: 'Do not Disturb settings changed for the current user.'
+      payload:
+        type: object
+        properties:
+          type:
+            type: string
+            enum:
+              - dnd_updated
+          user:
+            type: string
+          dnd_status:
+            type: object
+            properties:
+              dnd_enabled:
+                type: boolean
+              next_dnd_start_ts:
+                type: number
+              next_dnd_end_ts:
+                type: number
+              snooze_enabled:
+                type: boolean
+              snooze_endtime:
+                type: number
+    dndUpdatedUser:
+      summary: 'Do not Disturb settings changed for a member.'
+      payload:
+        type: object
+        properties:
+          type:
+            type: string
+            enum:
+              - dnd_updated_user
+          user:
+            type: string
+          dnd_status:
+            type: object
+            properties:
+              dnd_enabled:
+                type: boolean
+              next_dnd_start_ts:
+                type: number
+              next_dnd_end_ts:
+                type: number
+    emailDomainChanged:
+      summary: 'The workspace email domain has changed.'
+      payload:
+        type: object
+        properties:
+          type:
+            type: string
+            enum:
+              - email_domain_changed
+          email_domain:
+            type: string
+          event_ts:
+            type: string
+    emojiRemoved:
+      summary: 'A custom emoji has been removed.'
+      payload:
+        type: object
+        properties:
+          type:
+            type: string
+            enum:
+              - emoji_changed
+          subtype:
+            type: string
+            enum:
+              - remove
+          names:
+            type: array
+            items:
               type: string
-
+          event_ts:
+            type: string
     emojiAdded:
-      summary: A custom emoji has been added.
+      summary: 'A custom emoji has been added.'
       payload:
-        'application/schema+json;version=draft-07':
-          type: object
-          properties:
-            type:
-              type: string
-              enum: ['emoji_changed']
-            subtype:
-              type: string
-              enum: ['add']
-            name:
-              type: string
-            value:
-              type: string
-              format: uri
-            event_ts:
-              type: string
-
+        type: object
+        properties:
+          type:
+            type: string
+            enum:
+              - emoji_changed
+          subtype:
+            type: string
+            enum:
+              - add
+          name:
+            type: string
+          value:
+            type: string
+            format: uri
+          event_ts:
+            type: string
     fileChange:
-      summary: A file was changed.
+      summary: 'A file was changed.'
       payload:
-        'application/schema+json;version=draft-07':
-          type: object
-          properties:
-            type:
-              type: string
-              enum: ['file_change']
-            file_id:
-              type: string
-            file:
-              type: object
-              properties:
-                id:
-                  type: string
-
+        type: object
+        properties:
+          type:
+            type: string
+            enum:
+              - file_change
+          file_id:
+            type: string
+          file:
+            type: object
+            properties:
+              id:
+                type: string
     fileCommentAdded:
-      summary: A file comment was added.
+      summary: 'A file comment was added.'
       payload:
-        'application/schema+json;version=draft-07':
-          type: object
-          properties:
-            type:
-              type: string
-              enum: ['file_comment_added']
-            comment: {}
-            file_id:
-              type: string
-            file:
-              type: object
-              properties:
-                id:
-                  type: string
-
+        type: object
+        properties:
+          type:
+            type: string
+            enum:
+              - file_comment_added
+          comment: {}
+          file_id:
+            type: string
+          file:
+            type: object
+            properties:
+              id:
+                type: string
     fileCommentDeleted:
-      summary: A file comment was deleted.
+      summary: 'A file comment was deleted.'
       payload:
-        'application/schema+json;version=draft-07':
-          type: object
-          properties:
-            type:
-              type: string
-              enum: ['file_comment_deleted']
-            comment:
-              type: string
-            file_id:
-              type: string
-            file:
-              type: object
-              properties:
-                id:
-                  type: string
-
+        type: object
+        properties:
+          type:
+            type: string
+            enum:
+              - file_comment_deleted
+          comment:
+            type: string
+          file_id:
+            type: string
+          file:
+            type: object
+            properties:
+              id:
+                type: string
     fileCommentEdited:
-      summary: A file comment was edited.
+      summary: 'A file comment was edited.'
       payload:
-        'application/schema+json;version=draft-07':
-          type: object
-          properties:
-            type:
-              type: string
-              enum: ['file_comment_edited']
-            comment: {}
-            file_id:
-              type: string
-            file:
-              type: object
-              properties:
-                id:
-                  type: string
-
+        type: object
+        properties:
+          type:
+            type: string
+            enum:
+              - file_comment_edited
+          comment: {}
+          file_id:
+            type: string
+          file:
+            type: object
+            properties:
+              id:
+                type: string
     fileCreated:
-      summary: A file was created.
+      summary: 'A file was created.'
       payload:
-        'application/schema+json;version=draft-07':
-          type: object
-          properties:
-            type:
-              type: string
-              enum: ['file_created']
-            file_id:
-              type: string
-            file:
-              type: object
-              properties:
-                id:
-                  type: string
-
+        type: object
+        properties:
+          type:
+            type: string
+            enum:
+              - file_created
+          file_id:
+            type: string
+          file:
+            type: object
+            properties:
+              id:
+                type: string
     fileDeleted:
-      summary: A file was deleted.
+      summary: 'A file was deleted.'
       payload:
-        'application/schema+json;version=draft-07':
-          type: object
-          properties:
-            type:
-              type: string
-              enum: ['file_deleted']
-            file_id:
-              type: string
-            event_ts:
-              type: string
-
+        type: object
+        properties:
+          type:
+            type: string
+            enum:
+              - file_deleted
+          file_id:
+            type: string
+          event_ts:
+            type: string
     filePublic:
-      summary: A file was made public.
+      summary: 'A file was made public.'
       payload:
-        'application/schema+json;version=draft-07':
-          type: object
-          properties:
-            type:
-              type: string
-              enum: ['file_public']
-            file_id:
-              type: string
-            file:
-              type: object
-              properties:
-                id:
-                  type: string
-
+        type: object
+        properties:
+          type:
+            type: string
+            enum:
+              - file_public
+          file_id:
+            type: string
+          file:
+            type: object
+            properties:
+              id:
+                type: string
     fileShared:
-      summary: A file was shared.
+      summary: 'A file was shared.'
       payload:
-        'application/schema+json;version=draft-07':
-          type: object
-          properties:
-            type:
-              type: string
-              enum: ['file_shared']
-            file_id:
-              type: string
-            file:
-              type: object
-              properties:
-                id:
-                  type: string
-
+        type: object
+        properties:
+          type:
+            type: string
+            enum:
+              - file_shared
+          file_id:
+            type: string
+          file:
+            type: object
+            properties:
+              id:
+                type: string
     fileUnshared:
-      summary: A file was unshared.
+      summary: 'A file was unshared.'
       payload:
-        'application/schema+json;version=draft-07':
-          type: object
-          properties:
-            type:
-              type: string
-              enum: ['file_unshared']
-            file_id:
-              type: string
-            file:
-              type: object
-              properties:
-                id:
-                  type: string
-
+        type: object
+        properties:
+          type:
+            type: string
+            enum:
+              - file_unshared
+          file_id:
+            type: string
+          file:
+            type: object
+            properties:
+              id:
+                type: string
     goodbye:
-      summary: The server intends to close the connection soon.
+      summary: 'The server intends to close the connection soon.'
       payload:
-        'application/schema+json;version=draft-07':
-          type: object
-          properties:
-            type:
-              type: string
-              enum: ['goodbye']
-
+        type: object
+        properties:
+          type:
+            type: string
+            enum:
+              - goodbye
     groupArchive:
-      summary: A private channel was archived.
+      summary: 'A private channel was archived.'
       payload:
-        'application/schema+json;version=draft-07':
-          type: object
-          properties:
-            type:
-              type: string
-              enum: ['group_archive']
-            channel:
-              type: string
-
+        type: object
+        properties:
+          type:
+            type: string
+            enum:
+              - group_archive
+          channel:
+            type: string
     groupClose:
-      summary: You closed a private channel.
+      summary: 'You closed a private channel.'
       payload:
-        'application/schema+json;version=draft-07':
-          type: object
-          properties:
-            type:
-              type: string
-              enum: ['group_close']
-            user:
-              type: string
-            channel:
-              type: string
-
+        type: object
+        properties:
+          type:
+            type: string
+            enum:
+              - group_close
+          user:
+            type: string
+          channel:
+            type: string
     groupHistoryChanged:
-      summary: Bulk updates were made to a private channel's history.
+      summary: 'Bulk updates were made to a private channel''s history.'
       payload:
-        'application/schema+json;version=draft-07':
-          type: object
-          properties:
-            type:
-              type: string
-              enum: ['group_history_changed']
-            latest:
-              type: string
-            ts:
-              type: string
-            event_ts:
-              type: string
-
+        type: object
+        properties:
+          type:
+            type: string
+            enum:
+              - group_history_changed
+          latest:
+            type: string
+          ts:
+            type: string
+          event_ts:
+            type: string
     groupJoined:
-      summary: You joined a private channel.
+      summary: 'You joined a private channel.'
       payload:
-        'application/schema+json;version=draft-07':
-          type: object
-          properties:
-            type:
-              type: string
-              enum: ['group_joined']
-            channel:
-              type: object
-              properties:
-                id:
-                  type: string
-                name:
-                  type: string
-                created:
-                  type: number
-                creator:
-                  type: string
-
+        type: object
+        properties:
+          type:
+            type: string
+            enum:
+              - group_joined
+          channel:
+            type: object
+            properties:
+              id:
+                type: string
+              name:
+                type: string
+              created:
+                type: number
+              creator:
+                type: string
     groupLeft:
-      summary: You left a private channel.
+      summary: 'You left a private channel.'
       payload:
-        'application/schema+json;version=draft-07':
-          type: object
-          properties:
-            type:
-              type: string
-              enum: ['group_left']
-            channel:
-              type: string
-
+        type: object
+        properties:
+          type:
+            type: string
+            enum:
+              - group_left
+          channel:
+            type: string
     groupMarked:
-      summary: A private channel read marker was updated.
+      summary: 'A private channel read marker was updated.'
       payload:
-        'application/schema+json;version=draft-07':
-          type: object
-          properties:
-            type:
-              type: string
-              enum: ['group_marked']
-            channel:
-              type: string
-            ts:
-              type: string
-
+        type: object
+        properties:
+          type:
+            type: string
+            enum:
+              - group_marked
+          channel:
+            type: string
+          ts:
+            type: string
     groupOpen:
-      summary: You opened a private channel.
+      summary: 'You opened a private channel.'
       payload:
-        'application/schema+json;version=draft-07':
-          type: object
-          properties:
-            type:
-              type: string
-              enum: ['group_open']
-            user:
-              type: string
-            channel:
-              type: string
-
+        type: object
+        properties:
+          type:
+            type: string
+            enum:
+              - group_open
+          user:
+            type: string
+          channel:
+            type: string
     groupRename:
-      summary: A private channel was renamed.
+      summary: 'A private channel was renamed.'
       payload:
-        'application/schema+json;version=draft-07':
-          type: object
-          properties:
-            type:
-              type: string
-              enum: ['group_rename']
-            channel:
-              type: object
-              properties:
-                id:
-                  type: string
-                name:
-                  type: string
-                created:
-                  type: number
-
+        type: object
+        properties:
+          type:
+            type: string
+            enum:
+              - group_rename
+          channel:
+            type: object
+            properties:
+              id:
+                type: string
+              name:
+                type: string
+              created:
+                type: number
     groupUnarchive:
-      summary: A private channel was unarchived.
+      summary: 'A private channel was unarchived.'
       payload:
-        'application/schema+json;version=draft-07':
-          type: object
-          properties:
-            type:
-              type: string
-              enum: ['group_unarchive']
-            channel:
-              type: string
-            user:
-              type: string
-
+        type: object
+        properties:
+          type:
+            type: string
+            enum:
+              - group_unarchive
+          channel:
+            type: string
+          user:
+            type: string
     imClose:
-      summary: You closed a DM.
+      summary: 'You closed a DM.'
       payload:
-        'application/schema+json;version=draft-07':
-          type: object
-          properties:
-            type:
-              type: string
-              enum: ['im_close']
-            channel:
-              type: string
-            user:
-              type: string
-
+        type: object
+        properties:
+          type:
+            type: string
+            enum:
+              - im_close
+          channel:
+            type: string
+          user:
+            type: string
     imCreated:
-      summary: A DM was created.
+      summary: 'A DM was created.'
       payload:
-        'application/schema+json;version=draft-07':
-          type: object
-          properties:
-            type:
-              type: string
-              enum: ['im_created']
-            channel:
-              type: object
-              properties:
-                id:
-                  type: string
-                name:
-                  type: string
-                created:
-                  type: number
-                creator:
-                  type: string
-            user:
-              type: string
-
+        type: object
+        properties:
+          type:
+            type: string
+            enum:
+              - im_created
+          channel:
+            type: object
+            properties:
+              id:
+                type: string
+              name:
+                type: string
+              created:
+                type: number
+              creator:
+                type: string
+          user:
+            type: string
     imMarked:
-      summary: A direct message read marker was updated.
+      summary: 'A direct message read marker was updated.'
       payload:
-        'application/schema+json;version=draft-07':
-          type: object
-          properties:
-            type:
-              type: string
-              enum: ['im_marked']
-            channel:
-              type: string
-            ts:
-              type: string
-
+        type: object
+        properties:
+          type:
+            type: string
+            enum:
+              - im_marked
+          channel:
+            type: string
+          ts:
+            type: string
     imOpen:
-      summary: You opened a DM.
+      summary: 'You opened a DM.'
       payload:
-        'application/schema+json;version=draft-07':
-          type: object
-          properties:
-            type:
-              type: string
-              enum: ['im_open']
-            channel:
-              type: string
-            user:
-              type: string
-
+        type: object
+        properties:
+          type:
+            type: string
+            enum:
+              - im_open
+          channel:
+            type: string
+          user:
+            type: string
     manualPresenceChange:
-      summary: You manually updated your presence.
+      summary: 'You manually updated your presence.'
       payload:
-        'application/schema+json;version=draft-07':
-          type: object
-          properties:
-            type:
-              type: string
-              enum: ['manual_presence_change']
-            presence:
-              type: string
-
+        type: object
+        properties:
+          type:
+            type: string
+            enum:
+              - manual_presence_change
+          presence:
+            type: string
     memberJoinedChannel:
-      summary: A user joined a public or private channel.
+      summary: 'A user joined a public or private channel.'
       payload:
-        'application/schema+json;version=draft-07':
-          type: object
-          properties:
-            type:
-              type: string
-              enum: ['member_joined_channel']
-            user:
-              type: string
-            channel:
-              type: string
-            channel_type:
-              type: string
-              enum:
-                - C
-                - G
-            team:
-              type: string
-            inviter:
-              type: string
-
+        type: object
+        properties:
+          type:
+            type: string
+            enum:
+              - member_joined_channel
+          user:
+            type: string
+          channel:
+            type: string
+          channel_type:
+            type: string
+            enum:
+              - C
+              - G
+          team:
+            type: string
+          inviter:
+            type: string
     memberLeftChannel:
-      summary: A user left a public or private channel.
+      summary: 'A user left a public or private channel.'
       payload:
-        'application/schema+json;version=draft-07':
-          type: object
-          properties:
-            type:
-              type: string
-              enum: ['member_left_channel']
-            user:
-              type: string
-            channel:
-              type: string
-            channel_type:
-              type: string
-              enum:
-                - C
-                - G
-            team:
-              type: string
-
+        type: object
+        properties:
+          type:
+            type: string
+            enum:
+              - member_left_channel
+          user:
+            type: string
+          channel:
+            type: string
+          channel_type:
+            type: string
+            enum:
+              - C
+              - G
+          team:
+            type: string
     message:
-      summary: A message was sent to a channel.
+      summary: 'A message was sent to a channel.'
       payload:
-        'application/schema+json;version=draft-07':
-          type: object
-          properties:
-            type:
-              type: string
-              enum: ['message']
-            user:
-              type: string
-            channel:
-              type: string
-            text:
-              type: string
-            ts:
-              type: string
-            attachments:
-              type: array
-              items:
-                $ref: '#/components/schemas/attachment'
-            edited:
-              type: object
-              properties:
-                user:
-                  type: string
-                ts:
-                  type: string
-
+        type: object
+        properties:
+          type:
+            type: string
+            enum:
+              - message
+          user:
+            type: string
+          channel:
+            type: string
+          text:
+            type: string
+          ts:
+            type: string
+          attachments:
+            type: array
+            items:
+              $ref: '#/components/schemas/attachment'
+          edited:
+            type: object
+            properties:
+              user:
+                type: string
+              ts:
+                type: string
     outgoingMessage:
-      summary: A message was sent to a channel.
+      summary: 'A message was sent to a channel.'
       payload:
-        'application/schema+json;version=draft-07':
-          type: object
-          properties:
-            id:
-              type: number
-            type:
-              type: string
-              enum: ['message']
-            channel:
-              type: string
-            text:
-              type: string
+        type: object
+        properties:
+          id:
+            type: number
+          type:
+            type: string
+            enum:
+              - message
+          channel:
+            type: string
+          text:
+            type: string

--- a/examples/next/streetlights.yml
+++ b/examples/next/streetlights.yml
@@ -38,44 +38,47 @@ channels:
   event/{streetlightId}/lighting/measured:
     parameters:
       - $ref: '#/components/parameters/streetlightId'
-    publish:
-      $ref: '#/components/messages/lightMeasured'
+    subscribe:
+      summary: Receive information about environmental lighting conditions of a particular streetlight.
+      # operationId: receiveLightMeasurement
+      message:
+        $ref: '#/components/messages/lightMeasured'
 
   action/{streetlightId}/turn/on:
     parameters:
       - $ref: '#/components/parameters/streetlightId'
-    subscribe:
-      $ref: '#/components/messages/turnOnOff'
+    publish:
+      message:
+        $ref: '#/components/messages/turnOnOff'
 
   action/{streetlightId}/turn/off:
     parameters:
       - $ref: '#/components/parameters/streetlightId'
-    subscribe:
-      $ref: '#/components/messages/turnOnOff'
+    publish:
+      message:
+        $ref: '#/components/messages/turnOnOff'
 
   action/{streetlightId}/dim:
     parameters:
       - $ref: '#/components/parameters/streetlightId'
-    subscribe:
-      $ref: '#/components/messages/dimLight'
+    publish:
+      message:
+        $ref: '#/components/messages/dimLight'
 
 components:
   messages:
     lightMeasured:
       summary: Inform about environmental lighting conditions for a particular streetlight.
       payload:
-        'application/schema+json;version=draft-07':
-          $ref: "#/components/schemas/lightMeasuredPayload"
+        $ref: "#/components/schemas/lightMeasuredPayload"
     turnOnOff:
       summary: Command a particular streetlight to turn the lights on or off.
       payload:
-        'application/schema+json;version=draft-07':
-          $ref: "#/components/schemas/turnOnOffPayload"
+        $ref: "#/components/schemas/turnOnOffPayload"
     dimLight:
       summary: Command a particular streetlight to dim the lights.
       payload:
-        'application/schema+json;version=draft-07':
-          $ref: "#/components/schemas/dimLightPayload"
+        $ref: "#/components/schemas/dimLightPayload"
 
   schemas:
     lightMeasuredPayload:

--- a/versions/next/asyncapi.md
+++ b/versions/next/asyncapi.md
@@ -50,6 +50,7 @@ Means that the [application](#definitionsApplication) is a [consumer](#definitio
 		- [Servers Object](#A2SServers)
 		- [Channels Object](#channelsObject)
 		- [Channel Item Object](#channelItemObject)
+		- [Operation Object](#operationObject)
 		- [Stream Object](#streamObject)
 		- [Message Object](#messageObject)
 		- [Schema Wrapper Object](#schemaWrapperObject)
@@ -463,8 +464,8 @@ Describes the operations available on a single channel.
 Field Name | Type | Description
 ---|:---:|---
 <a name="channelItemObjectRef"></a>$ref | `string` | Allows for an external definition of this channel item. The referenced structure MUST be in the format of a [Channel Item Object](#channelItemObject). If there are conflicts between the referenced definition and this Channel Item's definition, the behavior is *undefined*.
-<a name="channelItemObjectSubscribe"></a>subscribe | [Message Object](#messageObject) &#124; Map[`"oneOf"`, [[Message Object](#messageObject)]] | A definition of the message a SUBSCRIBE operation will receive on this channel. `oneOf` is allowed here to specify multiple messages, however, **a message MUST be valid only against one of the referenced message objects.**
-<a name="channelItemObjectPublish"></a>publish | [Message Object](#messageObject) &#124; Map[`"oneOf"`, [[Message Object](#messageObject)]] | A definition of the message a PUBLISH operation will receive on this channel. `oneOf` is allowed here to specify multiple messages, however, **a message MUST be valid only against one of the referenced message objects.**
+<a name="channelItemObjectSubscribe"></a>subscribe | [Operation Object](#operationObject) | A definition of the SUBSCRIBE operation.
+<a name="channelItemObjectPublish"></a>publish | [Operation Object](#operationObject) | A definition of the PUBLISH operation.
 <a name="channelItemObjectParameters"></a>parameters | [[Parameter Object](#parameterObject) &#124; [Reference Object](#referenceObject)] | A list of the parameters included in the channel name. It SHOULD be present only when using channels with expressions (as defined by [RFC 6570 section 2.2](https://tools.ietf.org/html/rfc6570#section-2.2)).
 
 This object can be extended with [Specification Extensions](#specificationExtensions).
@@ -475,12 +476,111 @@ This object can be extended with [Specification Extensions](#specificationExtens
 {
   "subscribe": {
     "summary": "A user signed up.",
-    "description": "A longer description of the message",
+    "message": {
+      "description": "A longer description of the message",
+      "payload": {
+        "type": "object",
+        "properties": {
+          "user": {
+            "$ref": "#/components/schemas/user"
+          },
+          "signup": {
+            "$ref": "#/components/schemas/signup"
+          }
+        }
+      }
+    }
+  }
+}
+```
+
+```yaml
+subscribe:
+  summary: A user signed up.
+  message:
+    description: A longer description of the message
+    payload:
+      type: object
+      properties:
+        user:
+          $ref: "#/components/schemas/user"
+        signup:
+          $ref: "#/components/schemas/signup"
+```
+
+Using `oneOf` to specify multiple messages per operation:
+
+```json
+{
+  "subscribe": {
+    "message": {
+      "oneOf": [
+        { "$ref": "#/components/messages/signup" },
+        { "$ref": "#/components/messages/login" }
+      ]
+    }
+  }
+}
+```
+
+```yaml
+subscribe:
+  message:
+    oneOf:
+      - $ref: '#/components/messages/signup'
+      - $ref: '#/components/messages/login'
+```
+
+
+
+
+
+
+
+#### <a name="operationObject"></a>Operation Object
+
+Describes a publish or a subscribe operation.
+
+##### Fixed Fields
+
+Field Name | Type | Description
+---|:---:|---
+<a name="operationObjectSummary"></a>summary | `string` | A short summary of what the operation is about.
+<a name="operationObjectDescription"></a>description | `string` | A verbose explanation of the operation. [CommonMark syntax](http://spec.commonmark.org/) can be used for rich text representation.
+<a name="operationObjectTags"></a>tags | [[Tag Object](#tagObject)] | A list of tags for API documentation control. Tags can be used for logical grouping of operations.
+<a name="operationObjectExternalDocs"></a>externalDocs | [External Documentation Object](#externalDocumentationObject) | Additional external documentation for this operation.
+<a name="operationObjectMessage"></a>message | [Message Object](#messageObject) | A definition of the message that will be published or received on this channel. `oneOf` is allowed here to specify multiple messages, however, **a message MUST be valid only against one of the referenced message objects.**
+
+This object can be extended with [Specification Extensions](#specificationExtensions).
+
+##### Operation Object Example
+
+```json
+{
+  "summary": "Action to sign a user up.",
+  "description": "A longer description",
+  "tags": [
+    { "name": "user" },
+    { "name": "signup" },
+    { "name": "register" }
+  ],
+  "message": {
+    "headers": {
+      "type": "object",
+      "properties": {
+        "qos": {
+          "$ref": "#/components/schemas/MQTTQoSHeader"
+        },
+        "retainFlag": {
+          "$ref": "#/components/schemas/MQTTRetainHeader"
+        }
+      }
+    },
     "payload": {
       "type": "object",
       "properties": {
         "user": {
-          "$ref": "#/components/schemas/user"
+          "$ref": "#/components/schemas/userCreate"
         },
         "signup": {
           "$ref": "#/components/schemas/signup"
@@ -492,40 +592,28 @@ This object can be extended with [Specification Extensions](#specificationExtens
 ```
 
 ```yaml
-subscribe:
-  summary: A user signed up.
-  description: A longer description of the message
+summary: Action to sign a user up.
+description: A longer description
+tags:
+  - name: user
+  - name: signup
+  - name: register
+message:
+  headers:
+    type: object
+    properties:
+      qos:
+        $ref: "#/components/schemas/MQTTQoSHeader"
+      retainFlag:
+        $ref: "#/components/schemas/MQTTRetainHeader"
   payload:
     type: object
     properties:
       user:
-        $ref: "#/components/schemas/user"
+        $ref: "#/components/schemas/userCreate"
       signup:
         $ref: "#/components/schemas/signup"
 ```
-
-Using `oneOf` to specify multiple messages per operation:
-
-```json
-{
-  "subscribe": {
-    "oneOf": [
-      { "$ref": "#/components/messages/signup" },
-      { "$ref": "#/components/messages/login" }
-    ]
-  }
-}
-```
-
-```yaml
-subscribe:
-  oneOf:
-    - $ref: '#/components/messages/signup'
-    - $ref: '#/components/messages/login'
-```
-
-
-
 
 
 

--- a/versions/next/schema.json
+++ b/versions/next/schema.json
@@ -558,28 +558,59 @@
       }
     },
     "operation": {
-      "oneOf": [
-        { "$ref": "#/definitions/message" },
-        {
-          "type": "object",
-          "required": [ "oneOf" ],
-          "additionalProperties": false,
-          "patternProperties": {
-            "^x-": {
-              "$ref": "#/definitions/vendorExtension"
-            }
+      "type": "object",
+      "additionalProperties": false,
+      "patternProperties": {
+        "^x-": {
+          "$ref": "#/definitions/vendorExtension"
+        }
+      },
+      "properties": {
+        "summary": {
+          "type": "string"
+        },
+        "description": {
+          "type": "string"
+        },
+        "tags": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/tag"
           },
-          "properties": {
-            "oneOf": {
-              "type": "array",
-              "minItems": 2,
-              "items": {
-                "$ref": "#/definitions/message"
+          "uniqueItems": true
+        },
+        "externalDocs": {
+          "$ref": "#/definitions/externalDocs"
+        },
+        "message": {
+          "oneOf": [
+            {
+              "$ref": "#/definitions/message"
+            },
+            {
+              "type": "object",
+              "required": [
+                "oneOf"
+              ],
+              "additionalProperties": false,
+              "patternProperties": {
+                "^x-": {
+                  "$ref": "#/definitions/vendorExtension"
+                }
+              },
+              "properties": {
+                "oneOf": {
+                  "type": "array",
+                  "minItems": 2,
+                  "items": {
+                    "$ref": "#/definitions/message"
+                  }
+                }
               }
             }
-          }
+          ]
         }
-      ]
+      }
     },
     "stream": {
       "title": "Stream Object",
@@ -681,12 +712,13 @@
             }
           },
           "properties": {
+            "schemaFormat": {
+              "type": "string"
+            },
             "headers": {
-              "$ref": "#/definitions/schemaWrapper"
+              "$ref": "#/definitions/schema"
             },
-            "payload": {
-              "$ref": "#/definitions/schemaWrapper"
-            },
+            "payload": {},
             "tags": {
               "type": "array",
               "items": {
@@ -713,14 +745,6 @@
           }
         }
       ]
-    },
-    "schemaWrapper": {
-      "type": "object",
-      "minProperties": 1,
-      "maxProperties": 1,
-      "patternProperties": {
-        "": {}
-      }
     },
     "vendorExtension": {
       "description": "Any property starting with x- is valid.",


### PR DESCRIPTION
### What?
Prepares the spec for #77 and #54.

It also changes how schema format is defined. Changed from this:

```yaml
channels:
  event/{streetlightId}/lighting/measured:
    subscribe:
      payload:
        'application/schema+json;version=draft-07':
          $ref: "#/components/schemas/lightMeasuredPayload"
```

to this:

```yaml
channels:
  event/{streetlightId}/lighting/measured:
    subscribe:
      message:
        schemaFormat: 'application/schema+json;version=draft-07'
        payload:
          $ref: "#/components/schemas/lightMeasuredPayload"
```

### Why?

We need to accommodate the spec to do things like the following:

```yaml
channels:
  event/{streetlightId}/lighting/measured:
    subscribe:
      operationId: receiveLightMeasure
      contentType: 'application/json'
      message:
        schemaFormat: 'application/schema+json;version=draft-07'
        payload:
          $ref: "#/components/schemas/lightMeasuredPayload"
```

Notice that we'll have 2 new properties: `operationId` and `contentType`. Also, and since we could only have a single schema format per payload, it doesn't make sense to create another nesting level for it, but instead we specify it as the `schemaFormat` property. This also allows us to default to AsyncAPI 1.2.0/OpenAPI 3.0.0 schema format when it's not present, making it easier to migrate.

### But what happened with the schema format for headers?
Investigating a bit more, I realized that neither Avro nor Protobuf really offer a solution for headers, so it should be enough to provide our own schema format for headers. No options there.