### PR TITLE
Add name and title to message object

### DIFF
--- a/examples/next/streetlights.yml
+++ b/examples/next/streetlights.yml
@@ -62,16 +62,22 @@ channels:
 components:
   messages:
     lightMeasured:
+      name: lightMeasured
+      title: Light measured
       summary: Inform about environmental lighting conditions for a particular streetlight.
       payload:
         'application/schema+json;version=draft-07':
           $ref: "#/components/schemas/lightMeasuredPayload"
     turnOnOff:
+      name: turnOnOff
+      title: Turn on/off
       summary: Command a particular streetlight to turn the lights on or off.
       payload:
         'application/schema+json;version=draft-07':
           $ref: "#/components/schemas/turnOnOffPayload"
     dimLight:
+      name: dimLight
+      title: Dim light
       summary: Command a particular streetlight to dim the lights.
       payload:
         'application/schema+json;version=draft-07':

--- a/versions/next/asyncapi.md
+++ b/versions/next/asyncapi.md
@@ -675,6 +675,8 @@ Field Name | Type | Description
 ---|:---:|---
 <a name="messageObjectHeaders"></a>headers | [Schema Wrapper Object](#schemaWrapperObject) | Definition of the message headers. It MAY or MAY NOT define the protocol headers.
 <a name="messageObjectPayload"></a>payload | [Schema Wrapper Object](#schemaWrapperObject) | Definition of the message payload.
+<a name="messageObjectName"></a>name | `string` | A machine-friendly name for the message.
+<a name="messageObjectTitle"></a>title | `string` | A human-friendly title for the message.
 <a name="messageObjectSummary"></a>summary | `string` | A short summary of what the message is about.
 <a name="messageObjectDescription"></a>description | `string` | A verbose explanation of the message. [CommonMark syntax](http://spec.commonmark.org/) can be used for rich text representation.
 <a name="messageObjectTags"></a>tags | [[Tag Object](#tagObject)] | A list of tags for API documentation control. Tags can be used for logical grouping of messages.
@@ -686,6 +688,8 @@ This object can be extended with [Specification Extensions](#specificationExtens
 
 ```json
 {
+  "name": "UserSignup",
+  "title": "User signup",
   "summary": "Action to sign a user up.",
   "description": "A longer description",
   "tags": [
@@ -723,6 +727,8 @@ This object can be extended with [Specification Extensions](#specificationExtens
 ```
 
 ```yaml
+name: UserSignup
+title: User signup
 summary: Action to sign a user up.
 description: A longer description
 tags:
@@ -751,6 +757,8 @@ Example using Google's protobuf messages:
 
 ```json
 {
+  "name": "UserSignup",
+  "title": "User signup",
   "summary": "Action to sign a user up.",
   "description": "A longer description",
   "tags": [
@@ -772,6 +780,8 @@ Example using Google's protobuf messages:
 ```
 
 ```yaml
+name: UserSignup
+title: User signup
 summary: Action to sign a user up.
 description: A longer description
 tags:

--- a/versions/next/schema.json
+++ b/versions/next/schema.json
@@ -698,6 +698,14 @@
               "type": "string",
               "description": "A brief summary of the message."
             },
+            "name": {
+              "type": "string",
+              "description": "Name of the message."
+            },
+            "title": {
+              "type": "string",
+              "description": "A human-friendly title for the message."
+            },
             "description": {
               "type": "string",
               "description": "A longer description of the message. CommonMark is allowed."


### PR DESCRIPTION
### What?
Fixes #79 

### Why?
When a message is referenced, it's impossible for a tool (e.g., documentation renderer) to know the name of the message. Example:

```yaml
publish:
  $ref: '#/components/messages/myMessage'

components:
  messages:
    myMessage:
      payload:
        type: object
        properties:
          ...
```

The example above results in the following after resolving `$ref`s:

```yaml
publish:
  payload:
    type: object
    properties:
      ...
```

As you can see, the name `myMessage` is lost. That's why we need `name` and `title` (a more human-friendly version of the name).