### PR TITLE
Add contentType property to message object

### DIFF
--- a/examples/next/streetlights.yml
+++ b/examples/next/streetlights.yml
@@ -35,6 +35,8 @@ servers:
         - streetlights:dim
       - openIdConnectWellKnown: []
 
+defaultContentType: application/json
+
 channels:
   event/{streetlightId}/lighting/measured:
     parameters:

--- a/examples/next/streetlights.yml
+++ b/examples/next/streetlights.yml
@@ -70,6 +70,7 @@ components:
   messages:
     lightMeasured:
       summary: Inform about environmental lighting conditions for a particular streetlight.
+      contentType: application/json
       payload:
         $ref: "#/components/schemas/lightMeasuredPayload"
     turnOnOff:

--- a/versions/next/asyncapi.md
+++ b/versions/next/asyncapi.md
@@ -446,6 +446,29 @@ This object MAY be extended with [Specification Extensions](#specificationExtens
 
 
 
+#### <a name="defaultContentTypeString"></a>Default Content Type
+
+A string representing the default content type to use when encoding/decoding a message's payload. The value MUST be a specific media type (e.g. `application/json`). This value MUST be used by schema parsers when the [contentType](#messageObjectContentType) property is omitted.
+
+In case a message can't be encoded/decoded using this value, schema parsers MUST use their default content type.
+
+##### Default Content Type Example
+
+```json
+{
+  "defaultContentType": "application/json"
+}
+```
+
+```yaml
+defaultContentType: application/json
+```
+
+
+
+
+
+
 #### <a name="channelsObject"></a>Channels Object
 
 Holds the relative paths to the individual channel and their operations.
@@ -788,7 +811,7 @@ Field Name | Type | Description
 ---|:---:|---
 <a name="messageObjectHeaders"></a>headers | [Schema Wrapper Object](#schemaWrapperObject) | Definition of the message headers. It MAY or MAY NOT define the protocol headers.
 <a name="messageObjectPayload"></a>payload | [Schema Wrapper Object](#schemaWrapperObject) | Definition of the message payload.
-<a name="messageObjectContentType"></a>contentType | `string` | The Content-Type for encoding the message payload. The value MUST be a specific media type (e.g. `application/json`).
+<a name="messageObjectContentType"></a>contentType | `string` | The content type to use when encoding/decoding a message's payload. The value MUST be a specific media type (e.g. `application/json`). When omitted, the value MUST be the one specified on the [defaultContentType](#defaultContentTypeString) field.
 <a name="messageObjectSummary"></a>summary | `string` | A short summary of what the message is about.
 <a name="messageObjectDescription"></a>description | `string` | A verbose explanation of the message. [CommonMark syntax](http://spec.commonmark.org/) can be used for rich text representation.
 <a name="messageObjectTags"></a>tags | [[Tag Object](#tagObject)] | A list of tags for API documentation control. Tags can be used for logical grouping of messages.

--- a/versions/next/asyncapi.md
+++ b/versions/next/asyncapi.md
@@ -788,6 +788,7 @@ Field Name | Type | Description
 ---|:---:|---
 <a name="messageObjectHeaders"></a>headers | [Schema Wrapper Object](#schemaWrapperObject) | Definition of the message headers. It MAY or MAY NOT define the protocol headers.
 <a name="messageObjectPayload"></a>payload | [Schema Wrapper Object](#schemaWrapperObject) | Definition of the message payload.
+<a name="messageObjectContentType"></a>contentType | `string` | The Content-Type for encoding the message payload. The value MUST be a specific media type (e.g. `application/json`).
 <a name="messageObjectSummary"></a>summary | `string` | A short summary of what the message is about.
 <a name="messageObjectDescription"></a>description | `string` | A verbose explanation of the message. [CommonMark syntax](http://spec.commonmark.org/) can be used for rich text representation.
 <a name="messageObjectTags"></a>tags | [[Tag Object](#tagObject)] | A list of tags for API documentation control. Tags can be used for logical grouping of messages.
@@ -801,6 +802,7 @@ This object can be extended with [Specification Extensions](#specificationExtens
 {
   "summary": "Action to sign a user up.",
   "description": "A longer description",
+  "contentType": "application/json",
   "tags": [
     { "name": "user" },
     { "name": "signup" },
@@ -838,6 +840,7 @@ This object can be extended with [Specification Extensions](#specificationExtens
 ```yaml
 summary: Action to sign a user up.
 description: A longer description
+contentType: application/json
 tags:
   - name: user
   - name: signup

--- a/versions/next/schema.json
+++ b/versions/next/schema.json
@@ -48,6 +48,9 @@
       },
       "uniqueItems": true
     },
+    "defaultContentType": {
+      "type": "string"
+    },
     "channels": {
       "$ref": "#/definitions/channels"
     },

--- a/versions/next/schema.json
+++ b/versions/next/schema.json
@@ -721,6 +721,9 @@
             "schemaFormat": {
               "type": "string"
             },
+            "contentType": {
+              "type": "string"
+            },
             "headers": {
               "$ref": "#/definitions/schema"
             },


### PR DESCRIPTION
### What?
Fixes #54 

### Why?
See #54 

### Notes
We can infer the content type in most cases from the schema definition. For instance, if it's defined using JSON Schema we can consider the content type of the payload is JSON. If the schema format is XSD, we know it's XML. However, some schema formats allow for other types of encoding, like Protobuf, which supports sending the message as binary or as JSON.