### PR TITLE
Issue #78 addition of Correlation ID to specification

### DIFF
--- a/examples/next/correlation-id.yml
+++ b/examples/next/correlation-id.yml
@@ -1,0 +1,106 @@
+asyncapi: '2.0.0'
+id: 'urn:com:smartylighting:streetlights:server'
+info:
+  title: Correlation ID Example
+  version: '1.0.0'
+  description: A cut of the Streetlights API to test Correlation ID
+  license:
+    name: Apache 2.0
+    url: https://www.apache.org/licenses/LICENSE-2.0
+
+servers:
+  - url: api.streetlights.smartylighting.com:{port}
+    scheme: mqtt
+    description: Test broker
+    baseChannel: smartylighting/streetlights/1/0
+    variables:
+      port:
+        description: Secure connection (TLS) is available through port 8883.
+        default: '1883'
+        enum:
+          - '1883'
+          - '8883'
+    security:
+      - apiKey: []
+      - supportedOauthFlows:
+        - streetlights:on
+        - streetlights:off
+        - streetlights:dim
+      - openIdConnectWellKnown: []
+
+defaultContentType: application/json
+
+channels:
+  event/{streetlightId}/lighting/measured:
+    parameters:
+      - $ref: '#/components/parameters/streetlightId'
+    subscribe:
+      summary: Receive information about environmental lighting conditions of a particular streetlight.
+      operationId: receiveLightMeasurement
+      message:
+        $ref: '#/components/messages/lightMeasured'
+
+  action/{streetlightId}/dim:
+    parameters:
+      - $ref: '#/components/parameters/streetlightId'
+    publish:
+      operationId: dimLight
+      message:
+        $ref: '#/components/messages/dimLight'
+
+components:
+  messages:
+    lightMeasured:
+      name: lightMeasured
+      title: Light measured
+      summary: Inform about environmental lighting conditions for a particular streetlight.
+      correlationId:
+        location: "$message.header.correlationId"
+      contentType: application/json
+      payload:
+        $ref: "#/components/schemas/lightMeasuredPayload"
+    dimLight:
+      name: dimLight
+      title: Dim light
+      summary: Command a particular streetlight to dim the lights.
+      correlationId:
+        $ref: "#/components/correlationIds/sentAtCorrelator"
+      payload:
+        $ref: "#/components/schemas/dimLightPayload"
+
+  schemas:
+    lightMeasuredPayload:
+      type: object
+      properties:
+        lumens:
+          type: integer
+          minimum: 0
+          description: Light intensity measured in lumens.
+        sentAt:
+          $ref: "#/components/schemas/sentAt"
+    dimLightPayload:
+      type: object
+      properties:
+        percentage:
+          type: integer
+          description: Percentage to which the light should be dimmed to.
+          minimum: 0
+          maximum: 100
+        sentAt:
+          $ref: "#/components/schemas/sentAt"
+    sentAt:
+      type: string
+      format: date-time
+      description: Date and time when the message was sent.
+
+  parameters:
+    streetlightId:
+      name: streetlightId
+      description: The ID of the streetlight.
+      schema:
+        type: string
+
+  correlationIds:
+    sentAtCorrelator:
+      description: Data from message payload used as correlation ID
+      location: $message.payload.sentAt

--- a/examples/next/correlation-id.yml
+++ b/examples/next/correlation-id.yml
@@ -55,7 +55,7 @@ components:
       title: Light measured
       summary: Inform about environmental lighting conditions for a particular streetlight.
       correlationId:
-        location: "$message.header#/MQMD/CorrelationId"
+        location: "$message.header#/MQMD/CorrelId"
       contentType: application/json
       payload:
         $ref: "#/components/schemas/lightMeasuredPayload"

--- a/versions/next/asyncapi.md
+++ b/versions/next/asyncapi.md
@@ -2280,7 +2280,7 @@ The table below provides examples of runtime expressions and examples of their u
 
 Source Location | Example expression  | Notes
 ---|:---|:---|
-Message Header Property | `$message.header#/MQMD/CorrelationId` | Correlation ID is set using the `CorrelationID` value from the `MQMD` header.
+Message Header Property | `$message.header#/MQMD/CorrelId` | Correlation ID is set using the `CorrelId` value from the `MQMD` header.
 Message Payload Property | `$message.payload#/messageId` | Correlation ID is set using the `messageId` value from the message payload.
 
 Runtime expressions preserve the type of the referenced value.

--- a/versions/next/schema.json
+++ b/versions/next/schema.json
@@ -290,6 +290,17 @@
         },
         "parameters": {
           "$ref": "#/definitions/parameters"
+        },
+        "correlationIds": {
+          "type": "object",
+          "patternProperties": {
+            "^[a-zA-Z0-9\\.\\-_]+$": {
+              "oneOf": [
+                { "$ref": "#/definitions/Reference" },
+                { "$ref": "#/definitions/correlationId" }
+              ]
+            }
+          }
         }
       }
     },
@@ -734,6 +745,12 @@
               "$ref": "#/definitions/schema"
             },
             "payload": {},
+            "correlationId": {
+              "oneOf": [
+                { "$ref": "#/definitions/Reference" },
+                { "$ref": "#/definitions/correlationId" }
+              ]
+            },
             "tags": {
               "type": "array",
               "items": {
@@ -768,6 +785,34 @@
           }
         }
       ]
+    },
+    "correlationId": {
+      "type": "object",
+      "required": [
+        "location"
+      ],
+      "additionalProperties": false,
+      "patternProperties": {
+        "^x-": {
+          "$ref": "#/definitions/vendorExtension"
+        }
+      },
+      "properties": {
+        "description": {
+          "type": "string",
+          "description": "A optional description of the correlation ID. GitHub Flavored Markdown is allowed."
+        },
+        "type": {
+          "type": "string",
+          "description": "An optional type specification",
+          "enum": ["string", "integer", "number"]
+        },
+        "location": {
+          "type": "string",
+          "description": "A runtime expression that specifies the location of the correlation ID",
+          "pattern": "^\\$message\\.(header|payload)\\..*"
+        }
+      }
     },
     "vendorExtension": {
       "description": "Any property starting with x- is valid.",


### PR DESCRIPTION
Fixes #78 

As follows:

* Added Correlation ID object
* Added runtime expression support
* Added Correlation ID Map to Components Object
* Added Correlation ID to Message Object
* Updated schema and added example to test

A couple of bits of food for thought:

* Is the ABNF definition too restrictive?
* Is it right to match the ABNF definition in schema?
* **Would welcome suggestions as to whether more references are needed anywhere else in the specification as it stands i.e. defining a Correlation ID at a higher level than Message**
