### PR TITLE
Issue #112 change scope of Message Object headers to application headers only

### DIFF
--- a/examples/next/application-headers.yml
+++ b/examples/next/application-headers.yml
@@ -1,9 +1,9 @@
 asyncapi: '2.0.0'
 id: 'urn:com:smartylighting:streetlights:server'
 info:
-  title: Correlation ID Example
+  title: Application Headers example
   version: '1.0.0'
-  description: A cut of the Streetlights API to test Correlation ID
+  description: A cut of the Streetlights API to test application header changes supporting #112
   license:
     name: Apache 2.0
     url: https://www.apache.org/licenses/LICENSE-2.0

--- a/examples/next/application-headers.yml
+++ b/examples/next/application-headers.yml
@@ -51,8 +51,8 @@ components:
               minLength: 24
               maxLength: 24
               format: binary
-        replyTo:
-          $ref: "#/components/schemas/replyTo"
+        applicationInstanceId:
+          $ref: "#/components/schemas/applicationInstanceId"
       payload:
         $ref: "#/components/schemas/lightMeasuredPayload"
 
@@ -70,8 +70,8 @@ components:
       type: string
       format: date-time
       description: Date and time when the message was sent.
-    replyTo:
-      description: Name of replyTo queue
+    applicationInstanceId:
+      description: Unique identifier for a given instance of the publishing application
       type: string
 
   parameters:

--- a/examples/next/application-headers.yml
+++ b/examples/next/application-headers.yml
@@ -1,0 +1,82 @@
+asyncapi: '2.0.0'
+id: 'urn:com:smartylighting:streetlights:server'
+info:
+  title: Correlation ID Example
+  version: '1.0.0'
+  description: A cut of the Streetlights API to test Correlation ID
+  license:
+    name: Apache 2.0
+    url: https://www.apache.org/licenses/LICENSE-2.0
+
+servers:
+  - url: api.streetlights.smartylighting.com:{port}
+    scheme: mqtt
+    description: Test broker
+    baseChannel: smartylighting/streetlights/1/0
+    variables:
+      port:
+        description: Secure connection (TLS) is available through port 8883.
+        default: '1883'
+        enum:
+          - '1883'
+          - '8883'
+
+defaultContentType: application/json
+
+channels:
+  event/{streetlightId}/lighting/measured:
+    parameters:
+      - $ref: '#/components/parameters/streetlightId'
+    subscribe:
+      summary: Receive information about environmental lighting conditions of a particular streetlight.
+      operationId: receiveLightMeasurement
+      message:
+        $ref: '#/components/messages/lightMeasured'
+
+components:
+  messages:
+    lightMeasured:
+      name: lightMeasured
+      title: Light measured
+      summary: Inform about environmental lighting conditions for a particular streetlight.
+      correlationId:
+        location: "$message.header#/MQMD/CorrelId"
+      contentType: application/json
+      headers:
+        MQMD:
+          type: object
+          properties:
+            CorrelId:
+              type: string
+              minLength: 24
+              maxLength: 24
+              format: binary
+        replyTo:
+          $ref: "#/components/schemas/replyTo"
+      payload:
+        $ref: "#/components/schemas/lightMeasuredPayload"
+
+  schemas:
+    lightMeasuredPayload:
+      type: object
+      properties:
+        lumens:
+          type: integer
+          minimum: 0
+          description: Light intensity measured in lumens.
+        sentAt:
+          $ref: "#/components/schemas/sentAt"
+    sentAt:
+      type: string
+      format: date-time
+      description: Date and time when the message was sent.
+    replyTo:
+      description: Name of replyTo queue
+      type: string
+
+  parameters:
+    streetlightId:
+      name: streetlightId
+      description: The ID of the streetlight.
+      schema:
+        type: string

--- a/versions/next/asyncapi.md
+++ b/versions/next/asyncapi.md
@@ -618,11 +618,9 @@ This object can be extended with [Specification Extensions](#specificationExtens
   ],
   "message": {
     "headers": {
-      "qos": {
-        "$ref": "#/components/schemas/MQTTQoSHeader"
-      },
-      "retainFlag": {
-        "$ref": "#/components/schemas/MQTTRetainHeader"
+      "applicationInstanceId": {
+        "description": "Unique identifier for a given instance of the publishing application",
+        "type": "string"
       }
     },
     "payload": {
@@ -650,10 +648,9 @@ tags:
   - name: register
 message:
   headers:
-    qos:
-      $ref: "#/components/schemas/MQTTQoSHeader"
-    retainFlag:
-      $ref: "#/components/schemas/MQTTRetainHeader"
+    applicationInstanceId:
+      description: Unique identifier for a given instance of the publishing application
+      type: string
   payload:
     type: object
     properties:
@@ -839,13 +836,12 @@ This object can be extended with [Specification Extensions](#specificationExtens
   ],
   "headers": {
     "correlationId": {
+      "description": "Correlation ID set by application",
       "type": "string"
     },
-    "qos": {
-      "$ref": "#/components/schemas/MQTTQoSHeader"
-    },
-    "retainFlag": {
-      "$ref": "#/components/schemas/MQTTRetainHeader"
+    "applicationInstanceId": {
+      "description": "Unique identifier for a given instance of the publishing application",
+      "type": "string"
     }
   },
   "payload": {
@@ -878,11 +874,11 @@ tags:
   - name: register
 headers:
   correlationId:
+    description: Correlation ID set by application
     type: string
-  qos:
-    $ref: "#/components/schemas/MQTTQoSHeader"
-  retainFlag:
-    $ref: "#/components/schemas/MQTTRetainHeader"
+  applicationInstanceId:
+    description: Unique identifier for a given instance of the publishing application
+    type: string
 payload:
   type: object
   properties:
@@ -1096,11 +1092,9 @@ my.org.User
         }
       ],
       "headers": {
-        "qos": {
-          "$ref": "#/components/schemas/MQTTQoSHeader"
-        },
-        "retainFlag": {
-          "$ref": "#/components/schemas/MQTTRetainHeader"
+        "applicationInstanceId": {
+          "description": "Unique identifier for a given instance of the publishing application",
+          "type": "string"
         }
       },
       "payload": {
@@ -1163,10 +1157,9 @@ components:
         - name: user
         - name: signup
       headers:
-        qos:
-          $ref: "#/components/schemas/MQTTQoSHeader"
-        retainFlag:
-          $ref: "#/components/schemas/MQTTRetainHeader"
+        applicationInstanceId:
+          description: Unique identifier for a given instance of the publishing application
+          type: string
       payload:
         type: object
         properties:

--- a/versions/next/asyncapi.md
+++ b/versions/next/asyncapi.md
@@ -618,14 +618,11 @@ This object can be extended with [Specification Extensions](#specificationExtens
   ],
   "message": {
     "headers": {
-      "type": "object",
-      "properties": {
-        "qos": {
-          "$ref": "#/components/schemas/MQTTQoSHeader"
-        },
-        "retainFlag": {
-          "$ref": "#/components/schemas/MQTTRetainHeader"
-        }
+      "qos": {
+        "$ref": "#/components/schemas/MQTTQoSHeader"
+      },
+      "retainFlag": {
+        "$ref": "#/components/schemas/MQTTRetainHeader"
       }
     },
     "payload": {
@@ -653,12 +650,10 @@ tags:
   - name: register
 message:
   headers:
-    type: object
-    properties:
-      qos:
-        $ref: "#/components/schemas/MQTTQoSHeader"
-      retainFlag:
-        $ref: "#/components/schemas/MQTTRetainHeader"
+    qos:
+      $ref: "#/components/schemas/MQTTQoSHeader"
+    retainFlag:
+      $ref: "#/components/schemas/MQTTRetainHeader"
   payload:
     type: object
     properties:
@@ -814,8 +809,7 @@ Describes a message received on a given channel and operation.
 
 Field Name | Type | Description
 ---|:---:|---
-
-<a name="messageObjectHeaders"></a>headers | [Schema Wrapper Object](#schemaObject) | Definition of the message headers. It MAY or MAY NOT define the protocol headers.
+<a name="messageObjectHeaders"></a>headers | Map[`string`, [Schema Object](#schemaObject) &#124; [Reference Object](#referenceObject)] | Definition of the application headers. It **does not** define the protocol headers.
 <a name="messageObjectPayload"></a>payload | `any` | Definition of the message payload. It can be of any type but defaults to [Schema object](#schemaObject).
 <a name="messageObjectCorrelationId"></a>correlationId | [Correlation ID Object](#correlationIdObject) &#124; [Reference Object](#referenceObject) | Definition of the correlation ID used for message tracing or matching.
 <a name="messageObjectSchemaFormat"></a>schemaFormat | `string` | A string containing the name of the schema format/language used to define the message payload. If omitted, implementations should parse the payload as a [Schema object](#schemaObject).
@@ -844,14 +838,14 @@ This object can be extended with [Specification Extensions](#specificationExtens
     { "name": "register" }
   ],
   "headers": {
-    "type": "object",
-    "properties": {
-      "qos": {
-        "$ref": "#/components/schemas/MQTTQoSHeader"
-      },
-      "retainFlag": {
-        "$ref": "#/components/schemas/MQTTRetainHeader"
-      }
+    "correlationId": {
+      "type": "string"
+    },
+    "qos": {
+      "$ref": "#/components/schemas/MQTTQoSHeader"
+    },
+    "retainFlag": {
+      "$ref": "#/components/schemas/MQTTRetainHeader"
     }
   },
   "payload": {
@@ -883,12 +877,12 @@ tags:
   - name: signup
   - name: register
 headers:
-  type: object
-  properties:
-    qos:
-      $ref: "#/components/schemas/MQTTQoSHeader"
-    retainFlag:
-      $ref: "#/components/schemas/MQTTRetainHeader"
+  correlationId:
+    type: string
+  qos:
+    $ref: "#/components/schemas/MQTTQoSHeader"
+  retainFlag:
+    $ref: "#/components/schemas/MQTTRetainHeader"
 payload:
   type: object
   properties:
@@ -1102,14 +1096,11 @@ my.org.User
         }
       ],
       "headers": {
-        "type": "object",
-        "properties": {
-          "qos": {
-            "$ref": "#/components/schemas/MQTTQoSHeader"
-          },
-          "retainFlag": {
-            "$ref": "#/components/schemas/MQTTRetainHeader"
-          }
+        "qos": {
+          "$ref": "#/components/schemas/MQTTQoSHeader"
+        },
+        "retainFlag": {
+          "$ref": "#/components/schemas/MQTTRetainHeader"
         }
       },
       "payload": {
@@ -1172,12 +1163,10 @@ components:
         - name: user
         - name: signup
       headers:
-        type: object
-        properties:
-          qos:
-            $ref: "#/components/schemas/MQTTQoSHeader"
-          retainFlag:
-            $ref: "#/components/schemas/MQTTRetainHeader"
+        qos:
+          $ref: "#/components/schemas/MQTTQoSHeader"
+        retainFlag:
+          $ref: "#/components/schemas/MQTTRetainHeader"
       payload:
         type: object
         properties:
@@ -2232,7 +2221,7 @@ petstore_auth:
 
 ### <a name="correlationIdObject"></a>Correlation ID Object
 
-An object that specifies an identifier at design time that can used for message tracing and correlation.
+An object that specifies an identifier at design time that can used for message tracing and correlation. 
 
 For specifying and computing the location of a Correlation ID, a [runtime expression](#runtimeExpression) is used.
 

--- a/versions/next/schema.json
+++ b/versions/next/schema.json
@@ -742,7 +742,16 @@
               "type": "string"
             },
             "headers": {
-              "$ref": "#/definitions/schema"
+              "type": "object",
+              "additionalProperties": false,
+              "patternProperties": {
+                "^[a-zA-Z0-9\\.\\-_]+$": {
+                  "oneOf": [
+                    { "$ref": "#/definitions/Reference" },
+                    {"$ref": "#/definitions/schema" }
+                  ]
+                }
+              }
             },
             "payload": {},
             "correlationId": {

--- a/versions/next/schema.json
+++ b/versions/next/schema.json
@@ -743,14 +743,11 @@
             },
             "headers": {
               "type": "object",
-              "additionalProperties": false,
-              "patternProperties": {
-                "^[a-zA-Z0-9\\.\\-_]+$": {
-                  "oneOf": [
-                    { "$ref": "#/definitions/Reference" },
-                    {"$ref": "#/definitions/schema" }
-                  ]
-                }
+              "additionalProperties": {
+                "oneOf": [
+                  { "$ref": "#/definitions/Reference" },
+                  {"$ref": "#/definitions/schema" }
+                ]
               }
             },
             "payload": {},


### PR DESCRIPTION
Summary of changes:

* Changed the `headers` property from a Schema Object to a Map of Schema or Reference Objects
* Changed wording on `headers` property to constrain it to applications headers i.e. it does not include protocol headers, which will be defined by #42 
* Updated examples of headers throughout
* Changed JSON Schema and used `patternProperties` to define the map and constraints on types.
* Provided an example for testing.