### PR TITLE
Clean $refs in schema

### DIFF
--- a/versions/next/schema.json
+++ b/versions/next/schema.json
@@ -80,10 +80,13 @@
       ],
       "properties": {
         "$ref": {
-          "type": "string",
-          "format": "uri"
+          "$ref": "#/definitions/ReferenceObject"
         }
       }
+    },
+    "ReferenceObject": {
+      "type": "string",
+      "format": "uri"
     },
     "info": {
       "type": "object",
@@ -335,7 +338,7 @@
       },
       "properties": {
         "$ref": {
-          "type": "string"
+          "$ref": "#/definitions/ReferenceObject"
         },
         "format": {
           "type": "string"
@@ -531,7 +534,7 @@
       "minProperties": 1,
       "properties": {
         "$ref": {
-          "type": "string"
+          "$ref": "#/definitions/ReferenceObject"
         },
         "parameters": {
           "type": "array",
@@ -573,8 +576,8 @@
           "$ref": "#/definitions/schema"
         },
         "$ref": {
-	  "type": "string"
-	}
+          "$ref": "#/definitions/ReferenceObject"
+        }
       }
     },
     "operation": {


### PR DESCRIPTION
### What?
Makes use of a reusable `ReferenceObject` object.

### Why?
So we easily identify where we can use `$ref`s in the specification and also to embrace reusability.