### PR TITLE
Unify examples fields

### DIFF
--- a/versions/next/asyncapi.md
+++ b/versions/next/asyncapi.md
@@ -816,6 +816,7 @@ Field Name | Type | Description
 <a name="messageObjectDescription"></a>description | `string` | A verbose explanation of the message. [CommonMark syntax](http://spec.commonmark.org/) can be used for rich text representation.
 <a name="messageObjectTags"></a>tags | [[Tag Object](#tagObject)] | A list of tags for API documentation control. Tags can be used for logical grouping of messages.
 <a name="messageObjectExternalDocs"></a>externalDocs | [External Documentation Object](#externalDocumentationObject) | Additional external documentation for this message.
+<a name="messageObjectExamples"></a>examples | [Map[`string`, `any`]] | An array with examples of valid message objects.
 
 This object can be extended with [Specification Extensions](#specificationExtensions).
 
@@ -1237,6 +1238,7 @@ Field Name | Type | Description
 <a name="schemaObjectXml"></a>xml | [XML Object](#xmlObject) | This MAY be used only on properties schemas. It has no effect on root schemas. Adds Additional metadata to describe the XML representation format of this property.
 <a name="schemaObjectExternalDocs"></a>externalDocs | [External Documentation Object](#externalDocumentationObject) | Additional external documentation for this schema.
 <a name="schemaObjectExample"></a>example | Any | A free-form property to include an example of an instance for this schema. To represent examples that cannot naturally represented in JSON or YAML, a string value can be used to contain the example with escaping where necessary.
+<a name="schemaObjectExamples"></a>examples | [Any] | An array of free-form properties to include examples of instances for this schema. To represent examples that cannot naturally represented in JSON or YAML, a string value can be used to contain the example with escaping where necessary.
 <a name="schemaObjectDeprecated"></a> deprecated | `boolean` | Specifies that a schema is deprecated and SHOULD be transitioned out of usage. Default value is `false`.
 
 This object can be extended with [Specification Extensions](#specificationExtensions).

--- a/versions/next/schema.json
+++ b/versions/next/schema.json
@@ -474,7 +474,11 @@
         "externalDocs": {
           "$ref": "#/definitions/externalDocs"
         },
-        "example": {}
+        "example": {},
+        "examples": {
+          "type": "array",
+          "items": {}
+        }
       },
       "additionalProperties": false
     },
@@ -790,7 +794,12 @@
               "type": "boolean",
               "default": false
             },
-            "example": {}
+            "examples": {
+              "type": "array",
+              "items": {
+                "type": "object"
+              }
+            }
           }
         }
       ]


### PR DESCRIPTION
### What?
* Rename message's `example` field to `examples`.
* Add `examples` field to the schema object.

Fixes #172 

### Why?
To make it uniform across the spec. In the case of the schema object, we don't remove the existing `example` field to remain compatible with OpenAPI schemas.