### PR TITLE
Add maintainers guide

### DIFF
--- a/guides/contributors/README.md
+++ b/guides/contributors/README.md
@@ -1,0 +1,99 @@
+# Contributors Guide
+
+## Index
+
+<ol>
+  <li>
+    <a href="#understanding-the-specification">Understanding the specification</a>
+    <ol>
+      <li>
+        <a href="#basic-concepts">Basic concepts</a>
+      </li>
+      <li>
+        <a href="#areas-of-the-spec">Areas of the spec</a>
+      </li>
+      <li>
+        <a href="#what-does-ref-do">What does $ref do?</a>
+      </li>
+      <li>
+        <a href="#the-parts">JSON Schema</a>
+      </li>
+    </ol>
+  </li>
+  <li>
+    <a href="#tooling-landscape-and-plans">Tooling landscape and plans</a>
+    <ol>
+      <li>
+        <a href="#the-parser">The parser</a>
+      </li>
+      <li>
+        <a href="#the-generator">The generator</a>
+      </li>
+      <li>
+        <a href="#the-editor">The editor</a>
+      </li>
+      <li>
+        <a href="#tooling-plans">Tooling plans</a>
+      </li>
+    </ol>
+  </li>
+  <li>
+    <a href="#contributing-processes">Contributing processes</a>
+    <ol>
+      <li>
+        <a href="#task-management">Task management</a>
+        <ol>
+          <li>
+            <a href="#kanban-board">Kanban board</a>
+          </li>
+          <li>
+            <!-- Labels, epics, milestones, and releases -->
+            <a href="#creating-a-task">Creating a task</a>
+          </li>
+          <li>
+            <a href="#picking-a-task">Picking a task</a>
+          </li>
+          <li>
+            <a href="#working-on-a-task">Working on a task</a>
+          </li>
+          <li>
+            <a href="#definition-of-done">Definition of done</a>
+          </li>
+        </ol>
+      </li>
+      <li>
+        <a href="#coding">Coding</a>
+        <ol>
+          <li>
+            <a href="#pushing-early">Pushing early</a>
+          </li>
+          <li>
+            <a href="#reviewing-pull-requests">Reviewing pull requests</a>
+          </li>
+          <li>
+            <a href="#merging-your-code">Merging your code</a>
+          </li>
+        </ol>
+      </li>
+      <li>
+        <a href="#communication">Communication</a>
+        <ol>
+          <li>
+            <!-- Keep communication public when possible, be nice, other may not have enough context, do not accuse people, look for solutions instead of culprits, we're a team, don't try to impose your opinion, give voice to shy people, etc. -->
+            <a href="#communication-styles">Communication styles</a>
+          </li>
+          <li>
+            <!-- Different timezones, remote, people on spare time, etc. -->
+            <a href="#overcommunication">Overcommunication</a>
+          </li>
+          <li>
+            <!-- Recommendations on when to use Github/Zenhub, Slack, etc. -->
+            <a href="#communication-channels">Communication channels</a>
+          </li>
+        </ol>
+      </li>
+    </ol>
+  </li>
+</ol>
+
+

--- a/guides/contributors/README.md
+++ b/guides/contributors/README.md
@@ -1,99 +1,29 @@
-# Contributors Guide
+# Maintainers Guide
 
 ## Index
 
-<ol>
-  <li>
-    <a href="#understanding-the-specification">Understanding the specification</a>
-    <ol>
-      <li>
-        <a href="#basic-concepts">Basic concepts</a>
-      </li>
-      <li>
-        <a href="#areas-of-the-spec">Areas of the spec</a>
-      </li>
-      <li>
-        <a href="#what-does-ref-do">What does $ref do?</a>
-      </li>
-      <li>
-        <a href="#the-parts">JSON Schema</a>
-      </li>
-    </ol>
-  </li>
-  <li>
-    <a href="#tooling-landscape-and-plans">Tooling landscape and plans</a>
-    <ol>
-      <li>
-        <a href="#the-parser">The parser</a>
-      </li>
-      <li>
-        <a href="#the-generator">The generator</a>
-      </li>
-      <li>
-        <a href="#the-editor">The editor</a>
-      </li>
-      <li>
-        <a href="#tooling-plans">Tooling plans</a>
-      </li>
-    </ol>
-  </li>
-  <li>
-    <a href="#contributing-processes">Contributing processes</a>
-    <ol>
-      <li>
-        <a href="#task-management">Task management</a>
-        <ol>
-          <li>
-            <a href="#kanban-board">Kanban board</a>
-          </li>
-          <li>
-            <!-- Labels, epics, milestones, and releases -->
-            <a href="#creating-a-task">Creating a task</a>
-          </li>
-          <li>
-            <a href="#picking-a-task">Picking a task</a>
-          </li>
-          <li>
-            <a href="#working-on-a-task">Working on a task</a>
-          </li>
-          <li>
-            <a href="#definition-of-done">Definition of done</a>
-          </li>
-        </ol>
-      </li>
-      <li>
-        <a href="#coding">Coding</a>
-        <ol>
-          <li>
-            <a href="#pushing-early">Pushing early</a>
-          </li>
-          <li>
-            <a href="#reviewing-pull-requests">Reviewing pull requests</a>
-          </li>
-          <li>
-            <a href="#merging-your-code">Merging your code</a>
-          </li>
-        </ol>
-      </li>
-      <li>
-        <a href="#communication">Communication</a>
-        <ol>
-          <li>
-            <!-- Keep communication public when possible, be nice, other may not have enough context, do not accuse people, look for solutions instead of culprits, we're a team, don't try to impose your opinion, give voice to shy people, etc. -->
-            <a href="#communication-styles">Communication styles</a>
-          </li>
-          <li>
-            <!-- Different timezones, remote, people on spare time, etc. -->
-            <a href="#overcommunication">Overcommunication</a>
-          </li>
-          <li>
-            <!-- Recommendations on when to use Github/Zenhub, Slack, etc. -->
-            <a href="#communication-channels">Communication channels</a>
-          </li>
-        </ol>
-      </li>
-    </ol>
-  </li>
-</ol>
-
-
+1. [Understanding the specification](#understanding-the-specification)
+    1. [Basic concepts](#basic-concepts)
+    2. [Areas of the spec](#areas-of-the-spec)
+    3. [What does $ref do?](#what-does-ref-do)
+    4. [JSON Schema](#json-schema)
+2. [Tooling landscape and plans](#tooling-landscape-and-plans)
+    1. [The parser](#the-parser)
+    2. [The generator](#the-generator)
+    3. [The editor](#the-editor)
+    4. [Tooling plans](#tooling-plans)
+3. [Contributing processes](#contributing-processes)
+    1. [Task management](#task-management)
+        1. [Kanban board](#kanban-board)
+        2. [Creating a task](#creating-a-task) <!-- Labels, epics, milestones, and releases -->
+        3. [Picking a task](#picking-a-task)
+        4. [Working on a task](#working-on-a-task)
+        5. [Definition of done](#definition-of-done)
+    2. [Coding](#coding)
+        1. [Pushing early](#pushing-early)
+        2. [Reviewing pull requests](#reviewing-pull-requests)
+        3. [Merging your code](#merging-your-code)
+    3. [Communication](#communication)
+        1. [Communication styles](#communication-styles) <!-- Keep communication public when possible, be nice, other may not have enough context, do not accuse people, look for solutions instead of culprits, we're a team, don't try to impose your opinion, give voice to shy people, be professional, courteous, kind since others may not have enough, etc. -->
+        2. [Overcommunication](#overcommunication) <!-- Different time zones, remote, be understanding that most people are contributing using their spare time, etc. -->
+        3. [Communication channels](#communication-channels) <!-- Recommendations on when to use Github/Zenhub, Slack, etc. -->


### PR DESCRIPTION
### What?
The idea is to create an onboarding guide for maintainers (only for engineering work for now), to get people up to speed as soon as possible.

I'm pushing this early so you can review the index bullet points. **Please, let me know if you see something missing.** Some bullet points have invisible comments that you will only see by looking at the code and not the preview.

### Why?
It's hard for people to onboard the project. Let's try to make it easy 😊 