### PR TITLE
Remove stream object

### DIFF
--- a/examples/next/gitter-streaming.yml
+++ b/examples/next/gitter-streaming.yml
@@ -5,29 +5,38 @@ info:
   version: '1.0.0'
 
 servers:
-  - url: https://stream.gitter.im/v1/rooms/{roomId}/{resource}
+  - url: https://stream.gitter.im/v1
     scheme: https
     schemeVersion: '1.1'
-    variables:
-      roomId:
-        description: Id of the Gitter room.
-        examples:
-          - 53307860c3599d1de448e19d
-      resource:
-        description: The resource to consume.
-        enum:
-          - chatMessages
-          - events
     security:
       - httpBearerToken: []
 
-stream:
-  framing:
-    type: 'chunked'
-    delimiter: '\r\n'
-  read:
-    - $ref: '#/components/messages/chatMessage'
-    - $ref: '#/components/messages/heartbeat'
+channels:
+  /rooms/{roomId}/{resource}:
+    parameters:
+      - name: roomId
+        description: Id of the Gitter room.
+        schema:
+          type: string
+          examples:
+            - 53307860c3599d1de448e19d
+      - name: resource
+        description: The resource to consume.
+        schema:
+          type: string
+          enum:
+            - chatMessages
+            - events
+    subscribe:
+      protocolInfo:
+        http:
+          framing:
+            type: chunked
+            delimiter: '\r\n'
+      message:
+        oneOf:
+          - $ref: '#/components/messages/chatMessage'
+          - $ref: '#/components/messages/heartbeat'
 
 components:
   securitySchemes:

--- a/examples/next/gitter-streaming.yml
+++ b/examples/next/gitter-streaming.yml
@@ -30,9 +30,10 @@ channels:
     subscribe:
       protocolInfo:
         http:
-          framing:
-            type: chunked
-            delimiter: '\r\n'
+          response:
+            headers:
+              'Transfer-Encoding': 'chunked'
+              Trailer: '\r\n'
       message:
         oneOf:
           - $ref: '#/components/messages/chatMessage'

--- a/versions/next/asyncapi.md
+++ b/versions/next/asyncapi.md
@@ -52,7 +52,6 @@ Means that the [application](#definitionsApplication) is a [consumer](#definitio
       - [Channel Item Object](#channelItemObject)
       - [Operation Object](#operationObject)
       - [Operation Trait Object](#operationTraitObject)
-      - [Stream Object](#streamObject)
       - [Message Object](#messageObject)
       - [Message Trait Object](#messageTraitObject)
       - [Tag Object](#tagObject)
@@ -143,8 +142,7 @@ Field Name | Type | Description
 <a name="A2SId"></a>id | [Identifier](#A2SIdString) | **Required.** Identifier of the [application](#definitionsApplication) the AsyncAPI document is defining.
 <a name="A2SInfo"></a>info | [Info Object](#infoObject) | **Required.** Provides metadata about the API. The metadata can be used by the clients if needed.
 <a name="A2SServers"></a>servers | [Server Object](#serverObject) | An array of [Server Objects](#serverObject), which provide connectivity information to a target server.
-<a name="A2SChannels"></a>channels | [Channels Object](#channelsObject) | **Required unless [Stream Object](#streamObject) is provided.** The available channels and messages for the API.
-<a name="A2SStream"></a>stream | [Stream Object](#streamObject) | **Required unless [Channels Object](#channelsObject) is provided.** The messages and configuration for the streaming API.
+<a name="A2SChannels"></a>channels | [Channels Object](#channelsObject) | **Required** The available channels and messages for the API.
 <a name="A2SComponents"></a>components | [Components Object](#componentsObject) | An element to hold various schemas for the specification.
 <a name="A2STags"></a>tags | [[Tag Object](#tagObject)] | A list of tags used by the specification with additional metadata. Each tag name in the list MUST be unique.
 <a name="A2SExternalDocs"></a>externalDocs | [External Documentation Object](#externalDocumentationObject) | Additional external documentation.
@@ -835,87 +833,6 @@ amqp-0-9-1:
 
 
 
-
-#### <a name="streamObject"></a>Stream Object
-
-Holds the framing configuration and the read/write operations for the streaming API.
-
-##### Fixed Fields
-
-Field Name | Type | Description
----|:---:|---
-<a name="streamObjectFraming"></a>framing | [Stream Framing Object](#streamFramingObject) | **Required.** The framing configuration for the streaming API, i.e., whether is `chunked` or `sse` and the frame delimiter.
-<a name="streamObjectRead"></a>read | [[Message Object](#messageObject)] | A list of messages a consumer can read from the API.
-<a name="streamObjectWrite"></a>write | [[Message Object](#messageObject)] | A list of messages a consumer can send to the API.
-
-Either `read` or `write` MUST be provided.
-
-This object can be extended with [Specification Extensions](#specificationExtensions).
-
-##### Stream Object Example
-
-```json
-{
-  "stream": {
-    "framing": {
-      "type": "chunked",
-      "delimiter": "\r\n"
-    },
-    "read": [
-      { "$ref": "#/components/messages/chatMessage" },
-      { "$ref": "#/components/messages/heartbeat" }
-    ]
-  }
-}
-```
-
-```yaml
-stream:
-  framing:
-    type: 'chunked'
-    delimiter: '\r\n'
-  read:
-    - $ref: '#/components/messages/chatMessage'
-    - $ref: '#/components/messages/heartbeat'
-```
-
-
-
-
-
-
-
-
-
-#### <a name="streamFramingObject"></a>Stream Framing Object
-
-Holds the framing configuration for the streaming API.
-
-##### Fixed Fields
-
-Field Name | Type | Description
----|:---:|---
-<a name="streamFramingObjectType"></a>type | `string` | **Required.** The type of streaming API. Allowed values are `chunked` and `sse`.
-<a name="streamFramingObjectDelimiter"></a>delimiter | `string` | The string to use as the frame delimiter. Allowed values are `\r\n` and `\n`. Defaults to `\r\n`.
-
-This object can be extended with [Specification Extensions](#specificationExtensions).
-
-##### Stream Framing Object Example
-
-```json
-{
-  "framing": {
-    "type": "chunked",
-    "delimiter": "\r\n"
-  }
-}
-```
-
-```yaml
-framing:
-  type: 'chunked'
-  delimiter: '\r\n'
-```
 
 
 

--- a/versions/next/schema.json
+++ b/versions/next/schema.json
@@ -5,19 +5,8 @@
   "required": [
     "asyncapi",
     "id",
-    "info"
-  ],
-  "oneOf": [
-    {
-      "required": [
-        "channels"
-      ]
-    },
-    {
-      "required": [
-        "stream"
-      ]
-    }
+    "info",
+    "channels"
   ],
   "additionalProperties": false,
   "patternProperties": {
@@ -53,10 +42,6 @@
     },
     "channels": {
       "$ref": "#/definitions/channels"
-    },
-    "stream": {
-      "$ref": "#/definitions/stream",
-      "description": "The list of messages a consumer can read or write from/to a streaming API."
     },
     "components": {
       "$ref": "#/definitions/components"
@@ -687,86 +672,6 @@
               }
             }
           ]
-        }
-      }
-    },
-    "stream": {
-      "title": "Stream Object",
-      "type": "object",
-      "additionalProperties": false,
-      "patternProperties": {
-        "^x-": {
-          "$ref": "#/definitions/vendorExtension"
-        }
-      },
-      "minProperties": 1,
-      "properties": {
-        "framing": {
-          "title": "Stream Framing Object",
-          "type": "object",
-          "patternProperties": {
-            "^x-": {
-              "$ref": "#/definitions/vendorExtension"
-            }
-          },
-          "minProperties": 1,
-          "oneOf": [
-            {
-              "additionalProperties": false,
-              "properties": {
-                "type": {
-                  "type": "string",
-                  "enum": [
-                    "chunked"
-                  ]
-                },
-                "delimiter": {
-                  "type": "string",
-                  "enum": [
-                    "\\r\\n",
-                    "\\n"
-                  ],
-                  "default": "\\r\\n"
-                }
-              }
-            },
-            {
-              "additionalProperties": false,
-              "properties": {
-                "type": {
-                  "type": "string",
-                  "enum": [
-                    "sse"
-                  ]
-                },
-                "delimiter": {
-                  "type": "string",
-                  "enum": [
-                    "\\n\\n"
-                  ],
-                  "default": "\\n\\n"
-                }
-              }
-            }
-          ]
-        },
-        "read": {
-          "title": "Stream Read Object",
-          "type": "array",
-          "uniqueItems": true,
-          "minItems": 1,
-          "items": {
-            "$ref": "#/definitions/message"
-          }
-        },
-        "write": {
-          "title": "Stream Write Object",
-          "type": "array",
-          "uniqueItems": true,
-          "minItems": 1,
-          "items": {
-            "$ref": "#/definitions/message"
-          }
         }
       }
     },


### PR DESCRIPTION
### What?
Removes the `stream` object from the root of the document. From now on, everything can be defined using `channels`.

> Please, note that it doesn't mean we're not going to support HTTP streaming anymore. On the contrary, we're cleaning the syntax for better growth. See `gitter-streaming` example to get an idea of how it will look like.

### Why?
This is part of the strategy to unify everything in channels.