### PR TITLE
Adding a description for the channel item object

### DIFF
--- a/examples/next/streetlights.yml
+++ b/examples/next/streetlights.yml
@@ -39,6 +39,7 @@ defaultContentType: application/json
 
 channels:
   event/{streetlightId}/lighting/measured:
+    description: The topic on which measured values may be produced and consumed.
     parameters:
       - $ref: '#/components/parameters/streetlightId'
     subscribe:

--- a/versions/next/asyncapi.md
+++ b/versions/next/asyncapi.md
@@ -518,6 +518,7 @@ Describes the operations available on a single channel.
 Field Name | Type | Description
 ---|:---:|---
 <a name="channelItemObjectRef"></a>$ref | `string` | Allows for an external definition of this channel item. The referenced structure MUST be in the format of a [Channel Item Object](#channelItemObject). If there are conflicts between the referenced definition and this Channel Item's definition, the behavior is *undefined*.
+<a name="channelItemObjectDescription"></a>description | `string` | An optional description of this channel item.
 <a name="channelItemObjectSubscribe"></a>subscribe | [Operation Object](#operationObject) | A definition of the SUBSCRIBE operation.
 <a name="channelItemObjectPublish"></a>publish | [Operation Object](#operationObject) | A definition of the PUBLISH operation.
 <a name="channelItemObjectParameters"></a>parameters | [[Parameter Object](#parameterObject) &#124; [Reference Object](#referenceObject)] | A list of the parameters included in the channel name. It SHOULD be present only when using channels with expressions (as defined by [RFC 6570 section 2.2](https://tools.ietf.org/html/rfc6570#section-2.2)).
@@ -529,6 +530,7 @@ This object can be extended with [Specification Extensions](#specificationExtens
 
 ```json
 {
+  "description": "This channel is used to exchange messages about users signing up",
   "subscribe": {
     "summary": "A user signed up.",
     "message": {
@@ -556,6 +558,7 @@ This object can be extended with [Specification Extensions](#specificationExtens
 ```
 
 ```yaml
+description: This channel is used to exchange messages about users signing up
 subscribe:
   summary: A user signed up.
   message:

--- a/versions/next/asyncapi.md
+++ b/versions/next/asyncapi.md
@@ -518,7 +518,7 @@ Describes the operations available on a single channel.
 Field Name | Type | Description
 ---|:---:|---
 <a name="channelItemObjectRef"></a>$ref | `string` | Allows for an external definition of this channel item. The referenced structure MUST be in the format of a [Channel Item Object](#channelItemObject). If there are conflicts between the referenced definition and this Channel Item's definition, the behavior is *undefined*.
-<a name="channelItemObjectDescription"></a>description | `string` | An optional description of this channel item.
+<a name="channelItemObjectDescription"></a>description | `string` | An optional description of this channel item. [CommonMark syntax](http://spec.commonmark.org/) can be used for rich text representation.
 <a name="channelItemObjectSubscribe"></a>subscribe | [Operation Object](#operationObject) | A definition of the SUBSCRIBE operation.
 <a name="channelItemObjectPublish"></a>publish | [Operation Object](#operationObject) | A definition of the PUBLISH operation.
 <a name="channelItemObjectParameters"></a>parameters | [[Parameter Object](#parameterObject) &#124; [Reference Object](#referenceObject)] | A list of the parameters included in the channel name. It SHOULD be present only when using channels with expressions (as defined by [RFC 6570 section 2.2](https://tools.ietf.org/html/rfc6570#section-2.2)).

--- a/versions/next/schema.json
+++ b/versions/next/schema.json
@@ -575,6 +575,10 @@
             "$ref": "#/definitions/parameter"
           }
         },
+        "description": {
+          "type": "string",
+          "description": "A description of the topic."
+        },
         "publish": {
           "$ref": "#/definitions/operation"
         },

--- a/versions/next/schema.json
+++ b/versions/next/schema.json
@@ -577,7 +577,7 @@
         },
         "description": {
           "type": "string",
-          "description": "A description of the topic."
+          "description": "A description of the channel."
         },
         "publish": {
           "$ref": "#/definitions/operation"


### PR DESCRIPTION
This introduces a 'description' for the channel item object as discussed in #207 