### PR TITLE
Fixed a formatting issue with a bullet list of schema properties.

### DIFF
--- a/versions/next/asyncapi.md
+++ b/versions/next/asyncapi.md
@@ -1355,6 +1355,7 @@ The following properties are taken directly from the JSON Schema definition and 
 - enum
 
 The following properties are taken from the JSON Schema definition but their definitions were adjusted to the AsyncAPI Specification.
+
 - type - Value MUST be a string. Multiple types via an array are not supported.
 - allOf - Inline or referenced schema MUST be of a [Schema Object](#schemaObject) and not a standard JSON Schema.
 - oneOf - Inline or referenced schema MUST be of a [Schema Object](#schemaObject) and not a standard JSON Schema.


### PR DESCRIPTION
I noticed that the formatting of this section of properties was incorrect on the asyncapi web site (but fine when viewed in GitHub).  I assume this change will fix the problem, but I can't verify since I don't know how the website is displaying the MD.

Here is how it currently looks when rendered on the web site:

![image](https://user-images.githubusercontent.com/1890703/57016446-217dfb80-6be8-11e9-945b-89526117d1b7.png)

This is definitely one of my better open source contributions.  ;)

Signed-off-by: Eric Wittmann <eric.wittmann@gmail.com>