### PR TITLE
Simplify traits

### DIFF
--- a/examples/next/streetlights.yml
+++ b/examples/next/streetlights.yml
@@ -46,9 +46,7 @@ channels:
       summary: Receive information about environmental lighting conditions of a particular streetlight.
       operationId: receiveLightMeasurement
       traits:
-        - 
-          - $ref: '#/components/traits/docs'
-          - headerId: 'lighting-measured'
+        - $ref: '#/components/operationTraits/kafka'
       message:
         $ref: '#/components/messages/lightMeasured'
 
@@ -58,9 +56,7 @@ channels:
     publish:
       operationId: turnOn
       traits:
-        - 
-          - $ref: '#/components/traits/docs'
-          - headerId: 'turn-on'
+        - $ref: '#/components/operationTraits/kafka'
       message:
         $ref: '#/components/messages/turnOnOff'
 
@@ -70,9 +66,7 @@ channels:
     publish:
       operationId: turnOff
       traits:
-        - 
-          - $ref: '#/components/traits/docs'
-          - headerId: 'turn-off'
+        - $ref: '#/components/operationTraits/kafka'
       message:
         $ref: '#/components/messages/turnOnOff'
 
@@ -82,9 +76,7 @@ channels:
     publish:
       operationId: dimLight
       traits:
-        - 
-          - $ref: '#/components/traits/docs'
-          - headerId: 'dim'
+        - $ref: '#/components/operationTraits/kafka'
       message:
         $ref: '#/components/messages/dimLight'
 
@@ -96,9 +88,7 @@ components:
       summary: Inform about environmental lighting conditions for a particular streetlight.
       contentType: application/json
       traits:
-        - 
-          - $ref: '#/components/traits/docs'
-          - headerId: 'message-light-measured'
+        - $ref: '#/components/messageTraits/commonHeaders'
       payload:
         $ref: "#/components/schemas/lightMeasuredPayload"
     turnOnOff:
@@ -106,9 +96,7 @@ components:
       title: Turn on/off
       summary: Command a particular streetlight to turn the lights on or off.
       traits:
-        - 
-          - $ref: '#/components/traits/docs'
-          - headerId: 'message-turn-on-off'
+        - $ref: '#/components/messageTraits/commonHeaders'
       payload:
         $ref: "#/components/schemas/turnOnOffPayload"
     dimLight:
@@ -116,9 +104,7 @@ components:
       title: Dim light
       summary: Command a particular streetlight to dim the lights.
       traits:
-        - 
-          - $ref: '#/components/traits/docs'
-          - headerId: 'message-dim-light'
+        - $ref: '#/components/messageTraits/commonHeaders'
       payload:
         $ref: "#/components/schemas/dimLightPayload"
 
@@ -204,7 +190,18 @@ components:
       schema:
         type: string
 
-  traits:
-    docs:
-      externalDocs:
-        url: https://company.com/docs#{{headerId}}
+  messageTraits:
+    commonHeaders:
+      headers:
+        type: object
+        properties:
+          my-app-header:
+            type: integer
+            minimum: 0
+            maximum: 100
+  
+  operationTraits:
+    kafka:
+      protocolInfo:
+        kafka:
+          applicationId: my-app-id

--- a/versions/next/asyncapi.md
+++ b/versions/next/asyncapi.md
@@ -620,7 +620,7 @@ Field Name | Type | Description
 <a name="operationObjectTags"></a>tags | [[Tag Object](#tagObject)] | A list of tags for API documentation control. Tags can be used for logical grouping of operations.
 <a name="operationObjectExternalDocs"></a>externalDocs | [External Documentation Object](#externalDocumentationObject) | Additional external documentation for this operation.
 <a name="operationObjectProtocolInfo"></a>protocolInfo | Map[`string`, [Protocol Info Object](#protocolInfoObject)] | A free-form map where the keys describe the name of the protocol and the values describe protocol-specific definitions for the operation.
-<a name="operationObjectTraits"></a>traits | [[Operation Trait Object](#operationTraitObject)] &#124; [[[Operation Trait Object](#operationTraitObject), Map]] | A list of traits to apply to the operation object. The list MUST contain either a list of [Operation Trait Objects](#operationTraitObject) or a list of tuples where the first element is an [Operation Trait Object](#operationTraitObject)] and the second is a free-form object with the values of the variables a trait MAY use. **All the variables of a trait MUST be provided.** Traits MUST be merged into the operation object using the [JSON Merge Patch](https://tools.ietf.org/html/rfc7386) algorithm in the same order they are defined here.
+<a name="operationObjectTraits"></a>traits | [[Operation Trait Object](#operationTraitObject)] | A list of traits to apply to the operation object. Traits MUST be merged into the operation object using the [JSON Merge Patch](https://tools.ietf.org/html/rfc7386) algorithm in the same order they are defined here.
 <a name="operationObjectMessage"></a>message | [Message Object](#messageObject) | A definition of the message that will be published or received on this channel. `oneOf` is allowed here to specify multiple messages, however, **a message MUST be valid only against one of the referenced message objects.**
 
 This object can be extended with [Specification Extensions](#specificationExtensions).
@@ -663,11 +663,7 @@ This object can be extended with [Specification Extensions](#specificationExtens
     "noAck": true
   },
   "traits": [
-    { "$ref": "#/components/traits/kafka" },
-    [
-      { "$ref": "#/components/traits/docs" },
-      { "headerId": "publish-1234" }
-    ]
+    { "$ref": "#/components/operationTraits/kafka" }
   ]
 }
 ```
@@ -697,10 +693,7 @@ message:
 amqp-0-9-1:
   noAck: true
 traits:
-  - $ref: "#/components/traits/kafka"
-  -
-    - $ref: "#/components/traits/docs"
-    - headerId: publish-1234
+  - $ref: "#/components/operationTraits/kafka"
 ```
 
 
@@ -711,8 +704,6 @@ traits:
 Describes a trait that MAY be applied to an [Operation Object](#operationObject). This object MAY contain any property from the [Operation Object](#operationObject), except `message` and `traits`.
 
 If you're looking to apply traits to a message, see the [Message Trait Object](#messageTraitObject).
-
-All the string values of this object MUST support simple templating using the `{{` and `}}` delimiters.
 
 ##### Fixed Fields
 
@@ -743,19 +734,6 @@ This object can be extended with [Specification Extensions](#specificationExtens
 protocolInfo:
   amqp-0-9-1:
     noAck: true
-```
-
-```json
-{
-  "externalDocs": {
-    "url": "https://mycompany.com/docs#{{headerId}}"
-  }
-}
-```
-
-```yaml
-externalDocs:
-  url: "https://mycompany.com/docs#{{headerId}}"
 ```
 
 
@@ -872,7 +850,7 @@ Field Name | Type | Description
 <a name="messageObjectExternalDocs"></a>externalDocs | [External Documentation Object](#externalDocumentationObject) | Additional external documentation for this message.
 <a name="messageObjectProtocolInfo"></a>protocolInfo | Map[`string`, [Protocol Info Object](#protocolInfoObject)] | A free-form map where the keys describe the name of the protocol and the values describe protocol-specific definitions for the message.
 <a name="messageObjectExamples"></a>examples | [Map[`string`, `any`]] | An array with examples of valid message objects.
-<a name="messageObjectTraits"></a>traits | [[Message Trait Object](#messageTraitObject)] &#124; [[[Message Trait Object](#messageTraitObject), Map]] | A list of traits to apply to the message object. The list MUST contain either a list of [Message Trait Objects](#messageTraitObject) or a list of tuples where the first element is a [Message Trait Object](#messageTraitObject)] and the second is a free-form object with the values of the variables a trait may use. **All the variables of a trait MUST be provided.** Traits MUST be merged into the message object using the [JSON Merge Patch](https://tools.ietf.org/html/rfc7386) algorithm in the same order they are defined here. The resulting object MUST be a valid [Message Object](#messageObject).
+<a name="messageObjectTraits"></a>traits | [[Message Trait Object](#messageTraitObject)] | A list of traits to apply to the message object. Traits MUST be merged into the message object using the [JSON Merge Patch](https://tools.ietf.org/html/rfc7386) algorithm in the same order they are defined here. The resulting object MUST be a valid [Message Object](#messageObject).
 
 This object can be extended with [Specification Extensions](#specificationExtensions).
 
@@ -924,11 +902,7 @@ This object can be extended with [Specification Extensions](#specificationExtens
     }
   },
   "traits": [
-    { "$ref": "#/components/traits/kafka" },
-    [
-      { "$ref": "#/components/traits/docs" },
-      { "docId": "message-1234" }
-    ]
+    { "$ref": "#/components/messageTraits/commonHeaders" }
   ]
 }
 ```
@@ -966,10 +940,7 @@ amqp-0-9-1:
   properties:
     delivery_mode: 2
 traits:
-  - $ref: "#/components/traits/kafka"
-  -
-    - $ref: "#/components/traits/docs"
-    - docId: message-1234
+  - $ref: "#/components/messageTraits/commonHeaders"
 ```
 
 Example using Avro to define the payload:
@@ -1018,8 +989,6 @@ Describes a trait that MAY be applied to a [Message Object](#messageObject). Thi
 
 If you're looking to apply traits to an operation, see the [Operation Trait Object](#operationTraitObject).
 
-All the string values of this object MUST support simple templating using the `{{` and `}}` delimiters.
-
 ##### Fixed Fields
 
 Field Name | Type | Description
@@ -1051,19 +1020,6 @@ This object can be extended with [Specification Extensions](#specificationExtens
 ```yaml
 schemaFormat: 'application/vnd.apache.avro+json'
 contentType: application/json
-```
-
-```json
-{
-  "externalDocs": {
-    "url": "https://mycompany.com/docs#{{headerId}}"
-  }
-}
-```
-
-```yaml
-externalDocs:
-  url: 'https://mycompany.com/docs#{{headerId}}'
 ```
 
 #### <a name="tagsObject"></a>Tags Object
@@ -1172,7 +1128,8 @@ Field Name | Type | Description
 <a name="componentsSecuritySchemes"></a> securitySchemes| Map[`string`, [Security Scheme Object](#securitySchemeObject) \| [Reference Object](#referenceObject)] | An object to hold reusable [Security Scheme Objects](#securitySchemeObject).
 <a name="componentsParameters"></a> parameters | Map[`string`, [Parameter Object](#parameterObject) \| [Reference Object](#referenceObject)] | An object to hold reusable [Parameter Objects](#parameterObject).
 <a name="componentsCorrelationIDs"></a> correlationIds | Map[`string`, [Correlation ID Object](#correlationIdObject)] | An object to hold reusable [Correlation ID Objects](#correlationIdObject).
-<a name="componentsTraits"></a> traits | Map[`string`, [Operation Trait Object](#operationTraitObject) &#124; [Message Trait Object](#messageTraitObject)]  | An object to hold reusable [Operation Trait Objects](#operationTraitObject) and [Message Trait Objects](#messageTraitObject).
+<a name="componentsOperationTraits"></a> operationTraits | Map[`string`, [Operation Trait Object](#operationTraitObject)]  | An object to hold reusable [Operation Trait Objects](#operationTraitObject).
+<a name="componentsMessageTraits"></a> messageTraits | Map[`string`, [Message Trait Object](#messageTraitObject)]  | An object to hold reusable [Message Trait Objects](#messageTraitObject).
 
 This object can be extended with [Specification Extensions](#specificationExtensions).
 
@@ -1267,10 +1224,17 @@ my.org.User
       "location": "$message.header#/correlationId"
     }
   },
-  "traits": {
-    "docs": {
-      "externalDocs": {
-        "url": "https://mycompany.com/docs#{{headerId}}"
+  "messageTraits": {
+    "commonHeaders": {
+      "headers": {
+        "type": "object",
+        "properties": {
+          "my-app-header": {
+            "type": "integer",
+            "minimum": 0,
+            "maximum": 100
+          }
+        }
       }
     }
   }
@@ -1328,10 +1292,15 @@ components:
     default:
       description: Default Correlation ID
       location: $message.header#/correlationId
-  traits:
-    docs:
-      externalDocs:
-        url: "https://mycompany.com/docs#{{headerId}}"
+  messageTraits:
+    commonHeaders:
+      headers:
+        type: object
+        properties:
+          my-app-header:
+            type: integer
+            minimum: 0
+            maximum: 100
 ```
 
 #### <a name="schemaObject"></a>Schema Object

--- a/versions/next/schema.json
+++ b/versions/next/schema.json
@@ -295,8 +295,17 @@
             }
           }
         },
-        "traits": {
-          "$ref": "#/definitions/traits"
+        "operationTraits": {
+          "type": "object",
+          "additionalProperties": {
+            "$ref": "#/definitions/operationTrait"
+          }
+        },
+        "messageTraits": {
+          "type": "object",
+          "additionalProperties": {
+            "$ref": "#/definitions/messageTrait"
+          }
         }
       }
     },
@@ -873,19 +882,6 @@
         }
       }
     },
-    "traits": {
-      "type": "object",
-      "additionalProperties": {
-        "anyOf": [
-          {
-            "$ref": "#/definitions/operationTrait"
-          },
-          {
-            "$ref": "#/definitions/messageTrait"
-          }
-        ]
-      }
-    },
     "operationTrait": {
       "type": "object",
       "additionalProperties": false,
@@ -938,17 +934,14 @@
           "type": "string"
         },
         "headers": {
-          "type": "object",
-          "additionalProperties": {
-            "oneOf": [
-              {
-                "$ref": "#/definitions/Reference"
-              },
-              {
-                "$ref": "#/definitions/schema"
-              }
-            ]
-          }
+          "oneOf": [
+            {
+              "$ref": "#/definitions/Reference"
+            },
+            {
+              "$ref": "#/definitions/schema"
+            }
+          ]
         },
         "correlationId": {
           "oneOf": [


### PR DESCRIPTION
* Simplify traits by not allowing variable replacement.
* Separate traits in `messageTraits` and `operationTraits` in components as they are different object types.