### PR TITLE
Use maps instead of arrays when possible

### DIFF
--- a/examples/next/application-headers.yml
+++ b/examples/next/application-headers.yml
@@ -8,7 +8,8 @@ info:
     url: https://www.apache.org/licenses/LICENSE-2.0
 
 servers:
-  - url: api.streetlights.smartylighting.com:{port}
+  production:
+    url: api.streetlights.smartylighting.com:{port}
     protocol: mqtt
     description: Test broker
     variables:

--- a/examples/next/application-headers.yml
+++ b/examples/next/application-headers.yml
@@ -25,7 +25,8 @@ defaultContentType: application/json
 channels:
   smartylighting/streetlights/1/0/event/{streetlightId}/lighting/measured:
     parameters:
-      - $ref: '#/components/parameters/streetlightId'
+      streetlightId:
+        $ref: '#/components/parameters/streetlightId'
     subscribe:
       summary: Receive information about environmental lighting conditions of a particular streetlight.
       operationId: receiveLightMeasurement
@@ -77,7 +78,6 @@ components:
 
   parameters:
     streetlightId:
-      name: streetlightId
       description: The ID of the streetlight.
       schema:
         type: string

--- a/examples/next/correlation-id.yml
+++ b/examples/next/correlation-id.yml
@@ -8,7 +8,8 @@ info:
     url: https://www.apache.org/licenses/LICENSE-2.0
 
 servers:
-  - url: api.streetlights.smartylighting.com:{port}
+  production:
+    url: api.streetlights.smartylighting.com:{port}
     protocol: mqtt
     description: Test broker
     variables:

--- a/examples/next/correlation-id.yml
+++ b/examples/next/correlation-id.yml
@@ -32,7 +32,8 @@ defaultContentType: application/json
 channels:
   smartylighting/streetlights/1/0/event/{streetlightId}/lighting/measured:
     parameters:
-      - $ref: '#/components/parameters/streetlightId'
+      streetlightId:
+        $ref: '#/components/parameters/streetlightId'
     subscribe:
       summary: Receive information about environmental lighting conditions of a particular streetlight.
       operationId: receiveLightMeasurement
@@ -41,7 +42,8 @@ channels:
 
   smartylighting/streetlights/1/0/action/{streetlightId}/dim:
     parameters:
-      - $ref: '#/components/parameters/streetlightId'
+      streetlightId:
+        $ref: '#/components/parameters/streetlightId'
     publish:
       operationId: dimLight
       message:
@@ -94,7 +96,6 @@ components:
 
   parameters:
     streetlightId:
-      name: streetlightId
       description: The ID of the streetlight.
       schema:
         type: string

--- a/examples/next/gitter-streaming.yml
+++ b/examples/next/gitter-streaming.yml
@@ -15,13 +15,13 @@ servers:
 channels:
   /rooms/{roomId}/{resource}:
     parameters:
-      - name: roomId
+      roomId:
         description: Id of the Gitter room.
         schema:
           type: string
           examples:
             - 53307860c3599d1de448e19d
-      - name: resource
+      resource:
         description: The resource to consume.
         schema:
           type: string

--- a/examples/next/gitter-streaming.yml
+++ b/examples/next/gitter-streaming.yml
@@ -5,7 +5,8 @@ info:
   version: '1.0.0'
 
 servers:
-  - url: https://stream.gitter.im/v1
+  production:
+    url: https://stream.gitter.im/v1
     protocol: https
     protocolVersion: '1.1'
     security:

--- a/examples/next/rpc-client.yml
+++ b/examples/next/rpc-client.yml
@@ -15,7 +15,7 @@ servers:
 channels:
   '{queue}':
     parameters:
-      - name: queue
+      queue:
         schema:
           type: string
           pattern: '^amq\\.gen\\-.+$'

--- a/examples/next/rpc-client.yml
+++ b/examples/next/rpc-client.yml
@@ -8,7 +8,8 @@ info:
   version: '1.0.0'
 
 servers:
-  - url: rabbitmq.example.org
+  production:
+    url: rabbitmq.example.org
     protocol: amqp
 
 channels:

--- a/examples/next/rpc-server.yml
+++ b/examples/next/rpc-server.yml
@@ -15,7 +15,7 @@ servers:
 channels:
   '{queue}':
     parameters:
-      - name: queue
+      queue:
         schema:
           type: string
           pattern: '^amq\\.gen\\-.+$'

--- a/examples/next/rpc-server.yml
+++ b/examples/next/rpc-server.yml
@@ -8,7 +8,8 @@ info:
   version: '1.0.0'
 
 servers:
-  - url: rabbitmq.example.org
+  production:
+    url: rabbitmq.example.org
     protocol: amqp
 
 channels:

--- a/examples/next/slack-rtm.yml
+++ b/examples/next/slack-rtm.yml
@@ -5,7 +5,8 @@ info:
   version: '1.0.0'
 
 servers:
-  - url: https://slack.com/api/rtm.connect
+  production:
+    url: https://slack.com/api/rtm.connect
     protocol: https
     protocolVersion: '1.1'
     security:

--- a/examples/next/streetlights.yml
+++ b/examples/next/streetlights.yml
@@ -16,7 +16,8 @@ info:
     url: https://www.apache.org/licenses/LICENSE-2.0
 
 servers:
-  - url: api.streetlights.smartylighting.com:{port}
+  production:
+    url: api.streetlights.smartylighting.com:{port}
     protocol: mqtt
     description: Test broker
     variables:

--- a/examples/next/streetlights.yml
+++ b/examples/next/streetlights.yml
@@ -41,7 +41,8 @@ channels:
   smartylighting/streetlights/1/0/event/{streetlightId}/lighting/measured:
     description: The topic on which measured values may be produced and consumed.
     parameters:
-      - $ref: '#/components/parameters/streetlightId'
+      streetlightId:
+        $ref: '#/components/parameters/streetlightId'
     subscribe:
       summary: Receive information about environmental lighting conditions of a particular streetlight.
       operationId: receiveLightMeasurement
@@ -52,7 +53,8 @@ channels:
 
   smartylighting/streetlights/1/0/action/{streetlightId}/turn/on:
     parameters:
-      - $ref: '#/components/parameters/streetlightId'
+      streetlightId:
+        $ref: '#/components/parameters/streetlightId'
     publish:
       operationId: turnOn
       traits:
@@ -62,7 +64,8 @@ channels:
 
   smartylighting/streetlights/1/0/action/{streetlightId}/turn/off:
     parameters:
-      - $ref: '#/components/parameters/streetlightId'
+      streetlightId:
+        $ref: '#/components/parameters/streetlightId'
     publish:
       operationId: turnOff
       traits:
@@ -72,7 +75,8 @@ channels:
 
   smartylighting/streetlights/1/0/action/{streetlightId}/dim:
     parameters:
-      - $ref: '#/components/parameters/streetlightId'
+      streetlightId:
+        $ref: '#/components/parameters/streetlightId'
     publish:
       operationId: dimLight
       traits:
@@ -185,7 +189,6 @@ components:
 
   parameters:
     streetlightId:
-      name: streetlightId
       description: The ID of the streetlight.
       schema:
         type: string

--- a/versions/next/asyncapi.md
+++ b/versions/next/asyncapi.md
@@ -299,7 +299,35 @@ url: http://www.apache.org/licenses/LICENSE-2.0.html
 
 #### <a name="serversObject"></a>Servers Object
 
-The Servers Object is an array of Server Objects.
+The Servers Object is a map of [Server Objects](#serverObject).
+
+##### Patterned Fields
+
+Field Pattern | Type | Description
+---|:---:|---
+<a name="serversObjectServer"></a>`^[A-Za-z0-9_\-]+$` | [Server Object](#serverObject) | The definition of a server this application MAY connect to.
+
+##### Servers Object Example
+
+```json
+{
+  "production": {
+    "url": "development.gigantic-server.com",
+    "description": "Development server",
+    "protocol": "kafka",
+    "protocolVersion": "1.0.0"
+  }
+}
+```
+
+```yaml
+production:
+  url: development.gigantic-server.com
+  description: Development server
+  protocol: kafka
+  protocolVersion: '1.0.0'
+```
+
 
 #### <a name="serverObject"></a>Server Object
 
@@ -485,8 +513,6 @@ Channels are also known as "topics", "routing keys", "event types" or "paths".
 Field Pattern | Type | Description
 ---|:---:|---
 <a name="channelsObjectChannel"></a>{channel} | [Channel Item Object](#channelItemObject) | A relative path to an individual channel. The field name MUST be in the form of a [RFC 6570 URI template](https://tools.ietf.org/html/rfc6570). Query parameters and fragments SHALL NOT be used, instead use [protocolInfo](#protocolInfoObject) to define them.
-
-This object can be extended with [Specification Extensions](#specificationExtensions).
 
 ##### Channels Object Example
 

--- a/versions/next/asyncapi.md
+++ b/versions/next/asyncapi.md
@@ -547,7 +547,7 @@ Field Name | Type | Description
 <a name="channelItemObjectDescription"></a>description | `string` | An optional description of this channel item. [CommonMark syntax](http://spec.commonmark.org/) can be used for rich text representation.
 <a name="channelItemObjectSubscribe"></a>subscribe | [Operation Object](#operationObject) | A definition of the SUBSCRIBE operation.
 <a name="channelItemObjectPublish"></a>publish | [Operation Object](#operationObject) | A definition of the PUBLISH operation.
-<a name="channelItemObjectParameters"></a>parameters | [[Parameter Object](#parameterObject) &#124; [Reference Object](#referenceObject)] | A list of the parameters included in the channel name. It SHOULD be present only when using channels with expressions (as defined by [RFC 6570 section 2.2](https://tools.ietf.org/html/rfc6570#section-2.2)).
+<a name="channelItemObjectParameters"></a>parameters | [Parameters Object](#parametersObject) | A map of the parameters included in the channel name. It SHOULD be present only when using channels with expressions (as defined by [RFC 6570 section 2.2](https://tools.ietf.org/html/rfc6570#section-2.2)).
 <a name="channelItemObjectProtocolInfo"></a>protocolInfo | Map[`string`, [Protocol Info Object](#protocolInfoObject)] | A free-form map where the keys describe the name of the protocol and the values describe protocol-specific definitions for the channel.
 
 This object can be extended with [Specification Extensions](#specificationExtensions).
@@ -763,34 +763,31 @@ protocolInfo:
 
 
 
-#### <a name="parameterObject"></a>Parameter Object
+#### <a name="parametersObject"></a>Parameters Object
 
-Describes a parameter included in a channel name.
+Describes a map of parameters included in a channel name.
 
-##### Fixed Fields
+This map MUST contain all the parameters used in the parent channel name.
 
-Field Name | Type | Description
+##### Patterned Fields
+
+Field Pattern | Type | Description
 ---|:---:|---
-<a name="parameterObjectName"></a>name | `string` | The name of the parameter.
-<a name="parameterObjectDescription"></a>description | `string` | A verbose explanation of the parameter. [CommonMark syntax](http://spec.commonmark.org/) can be used for rich text representation.
-<a name="parameterObjectSchema"></a>schema | [Schema Object](#schemaObject) | Definition of the parameter.
+<a name="parametersObjectName"></a>`^[A-Za-z0-9_\-]+$` | [Parameter Object](#parameterObject) &#124; [Reference Object](#referenceObject) | The key represents the name of the parameter. It MUST match the parameter name used in the parent channel name.
 
-This object can be extended with [Specification Extensions](#specificationExtensions).
-
-##### Parameter Object Example
+##### Parameters Object Example
 
 ```json
 {
   "user/{userId}/signup": {
-    "parameters": [
-      {
-        "name": "userId",
+    "parameters": {
+      "userId": {
         "description": "Id of the user.",
         "schema": {
           "type": "string"
         }
       }
-    ],
+    },
     "subscribe": {
       "$ref": "#/components/messages/userSignedUp"
     }
@@ -801,7 +798,7 @@ This object can be extended with [Specification Extensions](#specificationExtens
 ```yaml
 user/{userId}/signup:
   parameters:
-    - name: userId
+    userId:
       description: Id of the user.
       schema:
         type: string
@@ -809,6 +806,53 @@ user/{userId}/signup:
     $ref: "#/components/messages/userSignedUp"
 ```
 
+
+
+
+
+#### <a name="parameterObject"></a>Parameter Object
+
+Describes a parameter included in a channel name.
+
+##### Fixed Fields
+
+Field Name | Type | Description
+---|:---:|---
+<a name="parameterObjectDescription"></a>description | `string` | A verbose explanation of the parameter. [CommonMark syntax](http://spec.commonmark.org/) can be used for rich text representation.
+<a name="parameterObjectSchema"></a>schema | [Schema Object](#schemaObject) | Definition of the parameter.
+
+This object can be extended with [Specification Extensions](#specificationExtensions).
+
+##### Parameter Object Example
+
+```json
+{
+  "user/{userId}/signup": {
+    "parameters": {
+      "userId": {
+        "description": "Id of the user.",
+        "schema": {
+          "type": "string"
+        }
+      }
+    },
+    "subscribe": {
+      "$ref": "#/components/messages/userSignedUp"
+    }
+  }
+}
+```
+
+```yaml
+user/{userId}/signup:
+  parameters:
+    userId:
+      description: Id of the user.
+      schema:
+        type: string
+  subscribe:
+    $ref: "#/components/messages/userSignedUp"
+```
 
 
 

--- a/versions/next/schema.json
+++ b/versions/next/schema.json
@@ -571,10 +571,8 @@
           "$ref": "#/definitions/ReferenceObject"
         },
         "parameters": {
-          "type": "array",
-          "uniqueItems": true,
-          "minItems": 1,
-          "items": {
+          "type": "object",
+          "additionalProperties": {
             "$ref": "#/definitions/parameter"
           }
         },
@@ -611,10 +609,6 @@
         "description": {
           "type": "string",
           "description": "A brief description of the parameter. This could contain examples of use. GitHub Flavored Markdown is allowed."
-        },
-        "name": {
-          "type": "string",
-          "description": "The name of the parameter."
         },
         "schema": {
           "$ref": "#/definitions/schema"

--- a/versions/next/schema.json
+++ b/versions/next/schema.json
@@ -30,11 +30,10 @@
       "$ref": "#/definitions/info"
     },
     "servers": {
-      "type": "array",
-      "items": {
+      "type": "object",
+      "additionalProperties": {
         "$ref": "#/definitions/server"
-      },
-      "uniqueItems": true
+      }
     },
     "defaultContentType": {
       "type": "string"


### PR DESCRIPTION
Changes:

* Makes parameters a map instead of an array. This way we always make sure a name is provided.
* Makes servers a map instead of an array. It gives us the advantage of assigning names to each server, e.g. production, development, staging, etc.

The reason behind this change is to facilitate the #107 and #108 features. These features make use of JSON Merge Patch and arrays are particularly "problematic" when trying to merge 2 or more. In the case of JSON Merge Patch, 2 arrays can't be merged and instead the second replaces the first one. If we remove unnecessary arrays from the spec, it will be possible to merge these objects too.