### PR TITLE
Fix operation verbs semantics and definitions

### DIFF
--- a/examples/next/application-headers.yml
+++ b/examples/next/application-headers.yml
@@ -9,7 +9,7 @@ info:
 
 servers:
   production:
-    url: api.streetlights.smartylighting.com:{port}
+    url: test.mosquitto.org:{port}
     protocol: mqtt
     description: Test broker
     variables:
@@ -28,7 +28,7 @@ channels:
       streetlightId:
         $ref: '#/components/parameters/streetlightId'
     publish:
-      summary: Inform about environmental lighting conditions for a particular streetlight.
+      summary: Inform about environmental lighting conditions of a particular streetlight.
       operationId: receiveLightMeasurement
       message:
         $ref: '#/components/messages/lightMeasured'
@@ -38,7 +38,7 @@ components:
     lightMeasured:
       name: lightMeasured
       title: Light measured
-      summary: Inform about environmental lighting conditions for a particular streetlight.
+      summary: Inform about environmental lighting conditions of a particular streetlight.
       correlationId:
         location: "$message.header#/MQMD/CorrelId"
       contentType: application/json

--- a/examples/next/application-headers.yml
+++ b/examples/next/application-headers.yml
@@ -27,8 +27,8 @@ channels:
     parameters:
       streetlightId:
         $ref: '#/components/parameters/streetlightId'
-    subscribe:
-      summary: Receive information about environmental lighting conditions of a particular streetlight.
+    publish:
+      summary: Inform about environmental lighting conditions for a particular streetlight.
       operationId: receiveLightMeasurement
       message:
         $ref: '#/components/messages/lightMeasured'

--- a/examples/next/correlation-id.yml
+++ b/examples/next/correlation-id.yml
@@ -9,7 +9,7 @@ info:
 
 servers:
   production:
-    url: api.streetlights.smartylighting.com:{port}
+    url: test.mosquitto.org:{port}
     protocol: mqtt
     description: Test broker
     variables:
@@ -35,7 +35,7 @@ channels:
       streetlightId:
         $ref: '#/components/parameters/streetlightId'
     publish:
-      summary: Inform about environmental lighting conditions for a particular streetlight.
+      summary: Inform about environmental lighting conditions of a particular streetlight.
       operationId: receiveLightMeasurement
       message:
         $ref: '#/components/messages/lightMeasured'
@@ -54,7 +54,7 @@ components:
     lightMeasured:
       name: lightMeasured
       title: Light measured
-      summary: Inform about environmental lighting conditions for a particular streetlight.
+      summary: Inform about environmental lighting conditions of a particular streetlight.
       correlationId:
         location: "$message.header#/MQMD/CorrelId"
       contentType: application/json

--- a/examples/next/correlation-id.yml
+++ b/examples/next/correlation-id.yml
@@ -34,8 +34,8 @@ channels:
     parameters:
       streetlightId:
         $ref: '#/components/parameters/streetlightId'
-    subscribe:
-      summary: Receive information about environmental lighting conditions of a particular streetlight.
+    publish:
+      summary: Inform about environmental lighting conditions for a particular streetlight.
       operationId: receiveLightMeasurement
       message:
         $ref: '#/components/messages/lightMeasured'
@@ -44,7 +44,7 @@ channels:
     parameters:
       streetlightId:
         $ref: '#/components/parameters/streetlightId'
-    publish:
+    subscribe:
       operationId: dimLight
       message:
         $ref: '#/components/messages/dimLight'

--- a/examples/next/rpc-client.yml
+++ b/examples/next/rpc-client.yml
@@ -24,7 +24,7 @@ channels:
         is: queue
         queue:
           exclusive: true
-    subscribe:
+    publish:
       operationId: receiveSumResult
       bindings:
         amqp:
@@ -46,7 +46,7 @@ channels:
         is: queue
         queue:
           durable: false
-    publish:
+    subscribe:
       operationId: requestSum
       bindings:
         amqp:

--- a/examples/next/rpc-server.yml
+++ b/examples/next/rpc-server.yml
@@ -24,7 +24,7 @@ channels:
         is: queue
         queue:
           exclusive: true
-    publish:
+    subscribe:
       operationId: sendSumResult
       bindings:
         amqp:
@@ -46,7 +46,7 @@ channels:
         is: queue
         queue:
           durable: false
-    subscribe:
+    publish:
       operationId: sum
       message:
         bindings:

--- a/examples/next/slack-rtm.yml
+++ b/examples/next/slack-rtm.yml
@@ -63,7 +63,7 @@ channels:
           - $ref: '#/components/messages/manualPresenceChange'
           - $ref: '#/components/messages/memberJoinedChannel'
           - $ref: '#/components/messages/message'
-    publish:
+    subscribe:
       message:
         $ref: '#/components/messages/outgoingMessage'
 

--- a/examples/next/streetlights.yml
+++ b/examples/next/streetlights.yml
@@ -43,8 +43,8 @@ channels:
     parameters:
       streetlightId:
         $ref: '#/components/parameters/streetlightId'
-    subscribe:
-      summary: Receive information about environmental lighting conditions of a particular streetlight.
+    publish:
+      summary: Inform about environmental lighting conditions for a particular streetlight.
       operationId: receiveLightMeasurement
       traits:
         - $ref: '#/components/operationTraits/kafka'
@@ -55,7 +55,7 @@ channels:
     parameters:
       streetlightId:
         $ref: '#/components/parameters/streetlightId'
-    publish:
+    subscribe:
       operationId: turnOn
       traits:
         - $ref: '#/components/operationTraits/kafka'
@@ -66,7 +66,7 @@ channels:
     parameters:
       streetlightId:
         $ref: '#/components/parameters/streetlightId'
-    publish:
+    subscribe:
       operationId: turnOff
       traits:
         - $ref: '#/components/operationTraits/kafka'
@@ -77,7 +77,7 @@ channels:
     parameters:
       streetlightId:
         $ref: '#/components/parameters/streetlightId'
-    publish:
+    subscribe:
       operationId: dimLight
       traits:
         - $ref: '#/components/operationTraits/kafka'

--- a/examples/next/streetlights.yml
+++ b/examples/next/streetlights.yml
@@ -1,5 +1,4 @@
 asyncapi: '2.0.0-rc2'
-id: 'urn:com:smartylighting:streetlights:server'
 info:
   title: Streetlights API
   version: '1.0.0'
@@ -17,7 +16,7 @@ info:
 
 servers:
   production:
-    url: api.streetlights.smartylighting.com:{port}
+    url: test.mosquitto.org:{port}
     protocol: mqtt
     description: Test broker
     variables:
@@ -44,7 +43,7 @@ channels:
       streetlightId:
         $ref: '#/components/parameters/streetlightId'
     publish:
-      summary: Inform about environmental lighting conditions for a particular streetlight.
+      summary: Inform about environmental lighting conditions of a particular streetlight.
       operationId: receiveLightMeasurement
       traits:
         - $ref: '#/components/operationTraits/kafka'
@@ -89,7 +88,7 @@ components:
     lightMeasured:
       name: lightMeasured
       title: Light measured
-      summary: Inform about environmental lighting conditions for a particular streetlight.
+      summary: Inform about environmental lighting conditions of a particular streetlight.
       contentType: application/json
       traits:
         - $ref: '#/components/messageTraits/commonHeaders'

--- a/versions/next/asyncapi.md
+++ b/versions/next/asyncapi.md
@@ -12,12 +12,12 @@ The AsyncAPI Specification is licensed under [The Apache License, Version 2.0](h
 
 ## Introduction
 
-The AsyncAPI Specification is a project used to describe and document message-driven APIs in a machine-readable format. It’s protocol-agnostic, so you can use it for APIs that work over any messaging protocol (e.g., AMQP, MQTT, WebSockets, Kafka, STOMP, etc).
+The AsyncAPI Specification is a project used to describe and document message-driven APIs in a machine-readable format. It’s protocol-agnostic, so you can use it for APIs that work over any protocol (e.g., AMQP, MQTT, WebSockets, Kafka, STOMP, HTTP, etc).
 
 The AsyncAPI Specification defines a set of files required to describe such an API.
 These files can then be used to create utilities, such as documentation, integration and/or testing tools.
 
-The file(s) MUST describe the operations an [application](#definitionsApplication) will perform. For instance, consider the following AsyncAPI definition snippet:
+The file(s) MUST describe the operations an [application](#definitionsApplication) accepts. For instance, consider the following AsyncAPI definition snippet:
 
 ```yaml
 user/signedup:
@@ -25,19 +25,20 @@ user/signedup:
     $ref: "#/components/messages/userSignUp"
 ```
 
-Means that the [application](#definitionsApplication) is a [consumer](#definitionsConsumer) because it subscribes to `user/signedup` [channel](#definitionsChannel) and receives userSignUp [messages](#definitionsMessage). 
+It means that the [application](#definitionsApplication) allows [consumers](#definitionsConsumer) to subscribe to the `user/signedup` [channel](#definitionsChannel) to receive userSignUp [messages](#definitionsMessage).
+
+**The AsyncAPI specification does not assume any kind of software topology, architecture or pattern.** Therefore, a server MAY be a message broker, a web server or any other kind of computer program capable of sending and/or receiving data. However, AsyncAPI offers a mechanism called "bindings" that aims to help with more specific information about the protocol and/or the topology.
 
 ## Table of Contents
 <!-- TOC depthFrom:2 depthTo:4 withLinks:1 updateOnSave:0 orderedList:0 -->
 
 - [Definitions](#definitions)
-  - [Message Broker](#definitionsMessageBroker)
-  - [Message](#definitionsMessage)
-  - [Channel](#definitionsChannel)
-  - [Protocol](#definitionsProtocol)
   - [Application](#definitionsApplication)
   - [Producer](#definitionsProducer)
   - [Consumer](#definitionsConsumer)
+  - [Message](#definitionsMessage)
+  - [Channel](#definitionsChannel)
+  - [Protocol](#definitionsProtocol)
 - [Specification](#specification)
 	- [Format](#format)
 	- [File Structure](#file-structure)
@@ -73,26 +74,23 @@ Means that the [application](#definitionsApplication) is a [consumer](#definitio
 
 ## <a name="definitions"/>Definitions
 
-#### <a name="definitionsMessageBroker"></a>Message Broker
-A message broker is an intermediary component that translates a [message](#definitionsMessage) from the messaging protocol of the sender to the messaging protocol of the receiver.  The message broker mediates interactions between applications, minimizing the mutual awareness that applications should have of each other in order to be able to exchange messages, effectively providing decoupling. A message broker MUST support at least one [protocol](#definitionsProtocol), thus enabling message exchanges between applications.  Importantly, the message broker is a mechanism that enables asynchronous application patterns such as publish/subscribe, fire and forget, request/reply and queuing. Additionally, the message broker MAY provide additional features such as persistence, storage/replay, authentication/authorization, protocol transformation and message integrity.
-
-#### <a name="definitionsMessage"></a>Message
-A message is the mechanism by which information is exchanged via a channel between [message brokers](#definitionsMessageBroker) and applications. A message MUST contain a payload and MAY also contain a header. The header MAY be subdivided into [protocol](#definitionsProtocol) defined headers and header properties defined by the application which can act as supporting metadata. The payload contains the data, defined by the application, which MUST be serialized into a format (JSON, XML, Avro, binary, etc.). Since a message is a generic mechanism, it can support multiple interaction patterns such as event, command, request, or response. 
-
-#### <a name="definitionsChannel"></a>Channel
-A channel is an addressable component, made available by the [message broker](#definitionsMessageBroker), for the organization of [messages](#definitionsMessage). [Producer](#definitionsProducer) applications send messages to channels and [consumer](#definitionsConsumer) applications consume messages from Channels. Message Brokers support many channel instances, allowing messages with different content to be addressed to different channels. Message Brokers MAY provide multiple channel types thus enabling different asynchronous application patterns such as topics, queues and exchanges. Depending on the message broker implementation, the channel MAY be included in the message via protocol defined headers.
-
-#### <a name="definitionsProtocol"></a>Protocol
-A protocol is the mechanism (wireline protocol OR API) by which [messages](#definitionsMessage) are exchanged between the application and the [channel](#definitionsChannel) hosted by the [message broker](#definitionsMessageBroker). Example protocol include, but are not limited to, AMQP, HTTP, JMS, Kafka, MQTT, STOMP, WebSocket.  
-
 #### <a name="definitionsApplication"></a>Application
-An application is any kind of computer program connected to a [message broker](#definitionsMessageBroker). It MUST be a [producer](#definitionsProducer), a [consumer](#definitionsConsumer) or both. An application MAY be a microservice, IoT device (sensor), mainframe process, etc. An application MAY be written in any number of different programming languages as long as they support the selected [protocol](#definitionsProtocol). An application MUST also use a protocol supported by the message broker in order to connect and exchange [messages](#definitionsMessage). 
+An application is any kind of computer program or a group of them. It MUST be a [producer](#definitionsProducer), a [consumer](#definitionsConsumer) or both. An application MAY be a microservice, IoT device (sensor), mainframe process, etc. An application MAY be written in any number of different programming languages as long as they support the selected [protocol](#definitionsProtocol). An application MUST also use a protocol supported by the server in order to connect and exchange [messages](#definitionsMessage).
 
 #### <a name="definitionsProducer"></a>Producer
-A producer is a type of application, connected to a [message broker](#definitionsMessageBroker) via a supported [protocol](#definitionsProtocol), that is creating [messages](#definitionsMessage) and addressing them to [channels](#definitionsChannel). A producer MAY be publishing to multiple channels depending on the message broker, protocol and use-case pattern. 
+A producer is a type of application, connected to a server, that is creating [messages](#definitionsMessage) and addressing them to [channels](#definitionsChannel). A producer MAY be publishing to multiple channels depending on the server, protocol, and use-case pattern. 
 
 #### <a name="definitionsConsumer"></a>Consumer
-A consumer is a type of application, connected to a [message broker](#definitionsMessageBroker) via a supported [protocol](#definitionsProtocol), that is consuming [messages](#definitionsMessage) from [channels](#definitionsChannel). A consumer MAY be consuming from multiple channels depending on the message broker, protocol and the use-case pattern. 
+A consumer is a type of application, connected to a server via a supported [protocol](#definitionsProtocol), that is consuming [messages](#definitionsMessage) from [channels](#definitionsChannel). A consumer MAY be consuming from multiple channels depending on the server, protocol, and the use-case pattern. 
+
+#### <a name="definitionsMessage"></a>Message
+A message is the mechanism by which information is exchanged via a channel between servers and applications. A message MUST contain a payload and MAY also contain headers. The headers MAY be subdivided into [protocol](#definitionsProtocol)-defined headers and header properties defined by the application which can act as supporting metadata. The payload contains the data, defined by the application, which MUST be serialized into a format (JSON, XML, Avro, binary, etc.). Since a message is a generic mechanism, it can support multiple interaction patterns such as event, command, request, or response. 
+
+#### <a name="definitionsChannel"></a>Channel
+A channel is an addressable component, made available by the server, for the organization of [messages](#definitionsMessage). [Producer](#definitionsProducer) applications send messages to channels and [consumer](#definitionsConsumer) applications consume messages from channels. Servers MAY support many channel instances, allowing messages with different content to be addressed to different channels. Depending on the server implementation, the channel MAY be included in the message via protocol-defined headers.
+
+#### <a name="definitionsProtocol"></a>Protocol
+A protocol is the mechanism (wireline protocol OR API) by which [messages](#definitionsMessage) are exchanged between the application and the [channel](#definitionsChannel). Example protocol include, but are not limited to, AMQP, HTTP, JMS, Kafka, MQTT, STOMP, WebSocket.  
 
 ## <a name="specification"></a>Specification
 
@@ -334,7 +332,7 @@ production:
 
 #### <a name="serverObject"></a>Server Object
 
-An object representing a Server. This is used to capture details about message brokers referenced by the API such as URIs, protocols and security configuration. Variable substitution can be used so that some details, for example usernames and passwords, can be injected by code generation tools.
+An object representing a message broker, a server or any other kind of computer program capable of sending and/or receiving data. This object is used to capture details such as URIs, protocols and security configuration. Variable substitution can be used so that some details, for example usernames and passwords, can be injected by code generation tools.
 
 ##### Fixed Fields
 


### PR DESCRIPTION
* Changes the meaning of the publish/subscribe verbs as it was in v1.
* Removes the definition of message broker and replaces any reference to it with the word "server" so we don't confuse people using AsyncAPI for non-broker-based topologies.