### PR TITLE
Add missing 'bindings' section

### DIFF
--- a/versions/2.0.0/asyncapi.md
+++ b/versions/2.0.0/asyncapi.md
@@ -597,10 +597,11 @@ subscribe:
         user:
           $ref: "#/components/schemas/user"
         signup:
-amqp:
-  is: queue
-  queue:
-    exclusive: true
+bindings:
+  amqp:
+    is: queue
+    queue:
+      exclusive: true
 ```
 
 Using `oneOf` to specify multiple messages per operation:


### PR DESCRIPTION
Hi,

The YAML example is missing the `bindings` section.

Fixes #275 