### PR TITLE
Initial cut at aws-sns publish example

### DIFF
--- a/examples/2.0.0/aws-sns-publish.yml
+++ b/examples/2.0.0/aws-sns-publish.yml
@@ -1,0 +1,46 @@
+asyncapi: 2.0.0
+id: 'https://github.com/asyncapi/asyncapi/blob/master/examples/2.0.0/aws-sns-publish.yml'
+info:
+  title: Simple AWS SNS Publish specification
+  description: |
+    Publishes a hello-world message to a particular queue
+  version: '0.1.0'
+servers:
+  test:
+    # This URL doesn't really describe a test server, but it does describe the
+    # top-level URL used to post a message to a given AWS region
+    url: https://sns.us-east-1.amazonaws.com/
+    description: Test environment for message publishing
+    protocol: sns
+    protocolVersion: "2010-03-31" #Can we reuse the "version" from down below?
+    bindings:
+      # Details on topicARNs: https://docs.aws.amazon.com/sns/latest/dg/sns-tutorial-create-topic.html
+      # This is a prefix, not a complete topicARN, but the prefix identifies
+      # the "server" environment (which is really just the account where this topic lives)
+      topicArnPrefix: "arn:aws:sns:us-east-1:123456789012:"
+channels:
+  helloWorld:
+    description: Topic used for hello world messages
+    bindings:
+      sns:
+        # This should be appended to the servers' topicARNPrefix to get the complete topicARN
+        # Can we do this automatically using JSON-Schema trickery somehow?
+        topicArnTopicName: "helloWorld"
+    publish:
+      message:
+        # The payload is equivalent to the AWS "Message" field
+        # Publish documentation: https://docs.aws.amazon.com/sns/latest/api/API_Publish.html
+        payload:
+          type: string
+          pattern: '^hello .+$'
+      bindings:
+        sns:
+          Action: Publish
+          # This is a concatenation of topicArnPrefix + topicArnTopicName from servers/channels above
+          TopicArn: "arn:aws:sns:us-east-1:123456789012:helloWorld"
+          # Details here: https://docs.aws.amazon.com/sns/latest/dg/sns-message-attributes.html
+          MessageAttributes:
+            # This is up to the application - any key/value mapping allowed here
+            messageType: HELLO_WORLD
+          # This is a default for all SNS messages
+          Version: "2010-03-31"

--- a/examples/2.0.0/aws-sns-publish.yml
+++ b/examples/2.0.0/aws-sns-publish.yml
@@ -1,46 +1,80 @@
 asyncapi: 2.0.0
 id: 'https://github.com/asyncapi/asyncapi/blob/master/examples/2.0.0/aws-sns-publish.yml'
 info:
-  title: Simple AWS SNS Publish specification
+  title: 'Simple AWS SNS Publish specification'
   description: |
-    Publishes a hello-world message to a particular queue
+    Specification for a service that publishes various "hello world"
+    type messages to the helloWorld SNS topic
   version: '0.1.0'
 servers:
-  test:
-    # This URL doesn't really describe a test server, but it does describe the
-    # top-level URL used to post a message to a given AWS region
-    url: https://sns.us-east-1.amazonaws.com/
-    description: Test environment for message publishing
-    protocol: sns
-    protocolVersion: "2010-03-31" #Can we reuse the "version" from down below?
+  development:
+    # This URL doesn't really describe a development server, but it does describe the
+    # top-level URL used to subscribe to messages from a given AWS region
+    url: 'https://sns.us-east-1.amazonaws.com/'
+    description: 'Development/test account for message publishing'
+    protocol: 'sns'
+    protocolVersion: '2010-03-31'
     bindings:
-      # Details on topicARNs: https://docs.aws.amazon.com/sns/latest/dg/sns-tutorial-create-topic.html
-      # This is a prefix, not a complete topicARN, but the prefix identifies
-      # the "server" environment (which is really just the account where this topic lives)
-      topicArnPrefix: "arn:aws:sns:us-east-1:123456789012:"
+      # AccountID for this environment
+      awsAccountID: "123456789012"
+  test:
+    url: 'https://sns.us-east-1.amazonaws.com/'
+    description: 'Development/test account for message publishing'
+    protocol: 'sns'
+    protocolVersion: '2010-03-31'
+    bindings:
+      awsAccountID: '123456789012'
+  production:
+    url: 'https://sns.us-east-1.amazonaws.com/'
+    description: 'Production account for message publishing'
+    protocol: 'sns'
+    protocolVersion: '2010-03-31'
+    bindings:
+      awsAccountID: '567891011121'
 channels:
   helloWorld:
-    description: Topic used for hello world messages
+    description: 'Topic used for hello world and similar messages'
     bindings:
-      sns:
-        # This should be appended to the servers' topicARNPrefix to get the complete topicARN
-        # Can we do this automatically using JSON-Schema trickery somehow?
-        topicArnTopicName: "helloWorld"
-    publish:
+      $ref: '#/components/channelBindings/sns/helloWorld'
+    subscribe:
       message:
-        # The payload is equivalent to the AWS "Message" field
-        # Publish documentation: https://docs.aws.amazon.com/sns/latest/api/API_Publish.html
-        payload:
-          type: string
-          pattern: '^hello .+$'
+        oneOf:
+          - $ref: '#/components/messages/helloWorldMessage'
+          - $ref: '#/components/messages/goodNightWorldMessage'
+components:
+  channelBindings:
+    sns:
+      helloWorld:
+        development:
+          topicArn: 'arn:aws:sns:us-east-1:123456789012:helloWorld-dev'
+        test:
+          topicArn: 'arn:aws:sns:us-east-1:123456789012:helloWorld'
+        production:
+          topicArn: 'arn:aws:sns:us-east-1:567891011121:helloWorld'
+  messages:
+    helloWorldMessage:
+      name: 'helloWorld'
+      title: 'Hello World message'
+      summary: 'Message sent to say Hello to the World'
+      payload:
+        type: string
+        const: 'Hello World!'
       bindings:
         sns:
-          Action: Publish
-          # This is a concatenation of topicArnPrefix + topicArnTopicName from servers/channels above
-          TopicArn: "arn:aws:sns:us-east-1:123456789012:helloWorld"
           # Details here: https://docs.aws.amazon.com/sns/latest/dg/sns-message-attributes.html
           MessageAttributes:
             # This is up to the application - any key/value mapping allowed here
-            messageType: HELLO_WORLD
-          # This is a default for all SNS messages
-          Version: "2010-03-31"
+            messageType: 'HELLO_WORLD'
+    goodNightWorldMessage:
+      name: 'goodNightWorld'
+      title: 'Goodnight World message'
+      summary: 'Message sent to say goodnight to the World'
+      payload:
+        type: string
+        const: 'Goodnight World!'
+      bindings:
+        sns:
+          # Details here: https://docs.aws.amazon.com/sns/latest/dg/sns-message-attributes.html
+          MessageAttributes:
+            # This is up to the application - any key/value mapping allowed here
+            messageType: 'GOODNIGHT_WORLD'


### PR DESCRIPTION
Draft attempt at a aws-sns publish example.

Some more work needs to be done, including answering a few questions:
1) How do we manage bindings of topicArn - which is a combination of "server"-type information, and "channel" type information. For now it is hardcoded, and thus somewhat duplicative
2) What should the bindings specify? All (standard) parameters/headers that are passed on a publication request?