### PR TITLE
Add bindings definition

### DIFF
--- a/versions/2.0.0/asyncapi.md
+++ b/versions/2.0.0/asyncapi.md
@@ -90,10 +90,10 @@ A message is the mechanism by which information is exchanged via a channel betwe
 A channel is an addressable component, made available by the server, for the organization of [messages](#definitionsMessage). [Producer](#definitionsProducer) applications send messages to channels and [consumer](#definitionsConsumer) applications consume messages from channels. Servers MAY support many channel instances, allowing messages with different content to be addressed to different channels. Depending on the server implementation, the channel MAY be included in the message via protocol-defined headers.
 
 #### <a name="definitionsProtocol"></a>Protocol
-A protocol is the mechanism (wireline protocol OR API) by which [messages](#definitionsMessage) are exchanged between the application and the [channel](#definitionsChannel). Example protocol include, but are not limited to, AMQP, HTTP, JMS, Kafka, MQTT, STOMP, WebSocket.  
+A protocol is the mechanism (wireline protocol or API) by which [messages](#definitionsMessage) are exchanged between the application and the [channel](#definitionsChannel). Example protocols include, but are not limited to, AMQP, HTTP, JMS, Kafka, MQTT, STOMP, WebSocket.  
 
 #### <a name="definitionsBindings"></a>Bindings
-An AsyncAPI binding (or "protocol binding") is a mechanism to define protocol-specific information. Therefore, infrastructure details, deployment information, and everything that's not related to the protocol MUST be left apart.
+A "binding" (or "protocol binding") is a mechanism to define protocol-specific information. Therefore, a protocol binding MUST define protocol-specific information only. 
 
 ## <a name="specification"></a>Specification
 

--- a/versions/2.0.0/asyncapi.md
+++ b/versions/2.0.0/asyncapi.md
@@ -93,7 +93,7 @@ A channel is an addressable component, made available by the server, for the org
 A protocol is the mechanism (wireline protocol OR API) by which [messages](#definitionsMessage) are exchanged between the application and the [channel](#definitionsChannel). Example protocol include, but are not limited to, AMQP, HTTP, JMS, Kafka, MQTT, STOMP, WebSocket.  
 
 #### <a name="definitionsBindings"></a>Bindings
-An AsyncAPI binding (or "protocol binding") is a mechanism to define protocol-specific information that's necessary to utilize the API. Therefore, infrastructure details, deployment information, and everything that's not related to how to communicate with the API MUST be left apart.
+An AsyncAPI binding (or "protocol binding") is a mechanism to define protocol-specific information. Therefore, infrastructure details, deployment information, and everything that's not related to the protocol MUST be left apart.
 
 ## <a name="specification"></a>Specification
 

--- a/versions/2.0.0/asyncapi.md
+++ b/versions/2.0.0/asyncapi.md
@@ -27,7 +27,7 @@ user/signedup:
 
 It means that the [application](#definitionsApplication) allows [consumers](#definitionsConsumer) to subscribe to the `user/signedup` [channel](#definitionsChannel) to receive userSignUp [messages](#definitionsMessage).
 
-**The AsyncAPI specification does not assume any kind of software topology, architecture or pattern.** Therefore, a server MAY be a message broker, a web server or any other kind of computer program capable of sending and/or receiving data. However, AsyncAPI offers a mechanism called "bindings" that aims to help with more specific information about the protocol and/or the topology.
+**The AsyncAPI specification does not assume any kind of software topology, architecture or pattern.** Therefore, a server MAY be a message broker, a web server or any other kind of computer program capable of sending and/or receiving data. However, AsyncAPI offers a mechanism called "bindings" that aims to help with more specific information about the protocol.
 
 ## Table of Contents
 <!-- TOC depthFrom:2 depthTo:4 withLinks:1 updateOnSave:0 orderedList:0 -->
@@ -91,6 +91,9 @@ A channel is an addressable component, made available by the server, for the org
 
 #### <a name="definitionsProtocol"></a>Protocol
 A protocol is the mechanism (wireline protocol OR API) by which [messages](#definitionsMessage) are exchanged between the application and the [channel](#definitionsChannel). Example protocol include, but are not limited to, AMQP, HTTP, JMS, Kafka, MQTT, STOMP, WebSocket.  
+
+#### <a name="definitionsBindings"></a>Bindings
+An AsyncAPI binding (or "protocol binding") is a mechanism to define protocol-specific information that's necessary to utilize the API. Therefore, infrastructure details, deployment information, and everything that's not related to how to communicate with the API MUST be left apart.
 
 ## <a name="specification"></a>Specification
 


### PR DESCRIPTION
### What?
I'm adding the definition of "binding" (or "protocol binding") and an incorrect piece of text saying that a "binding" can contain topology-related information.

### Why?
Make clear what is a "binding". We had definitions for what channel bindings, operation bindings, message bindings, and server bindings must be. However, we didn't have a definition of "binding" itself and it was leading to multiple interpretations.

### Why am I removing "and/or the topology"?
Bindings are one of the most exciting features of AsyncAPI. It lets you dig down to the specifics of each protocol without polluting the core spec. That said, bindings are also one of the most dangerous features in terms of spec evolution. We don't want bindings to become a black box where anyone can put whatever they want, from topology information to infrastructure/deployment details. We have specification extensions for that purpose and we'll give them more power soon with the creation of an extension registry.