### PR TITLE
fix: make sure headers must be object type

### DIFF
--- a/versions/2.0.0/schema.json
+++ b/versions/2.0.0/schema.json
@@ -643,7 +643,7 @@
                   "allOf": [
                     { "$ref": "#/definitions/schema" },
                     { "properties": {
-                      "type": { "enum": [ "object" ] }
+                      "type": { "const": "object" }
                     }
                   }
                   ]

--- a/versions/2.0.0/schema.json
+++ b/versions/2.0.0/schema.json
@@ -640,7 +640,13 @@
                   "type": "string"
                 },
                 "headers": {
-                  "$ref": "#/definitions/schema"
+                  "allOf": [
+                    { "$ref": "#/definitions/schema" },
+                    { "properties": {
+                      "type": { "enum": [ "object" ] }
+                    }
+                  }
+                  ]
                 },
                 "payload": {},
                 "correlationId": {


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow our contribution guidelines
2. Test your changes and attach their results to the pull request.
3. Update the relevant documentation.
-->

**Description**

- According to specification message headers must be defined as a schema of an object. Other types are not allowed.
- Solution based on https://json-schema.org/understanding-json-schema/reference/combining.html#id5

now validation fails with:
```
"headers": {
    "type": "integer",
    "enum": [1, 2]
}
```

but it is allowing:
```
"headers": {
    "type": "object",
    "properties": {
      "my-app-header": {
        "type": "integer",
        "minimum": 0,
        "maximum": 100
      }
    }
  }
```
**Related issue(s)**
See also https://github.com/asyncapi/parser-js/issues/68

**Comment**
I assume that once this is merged, I also need to create a PR to `asyncapi-node`. See also https://github.com/asyncapi/asyncapi/issues/395