### PR TITLE
Revert "Change examples structure"

### DIFF
--- a/versions/2.0.0/asyncapi.md
+++ b/versions/2.0.0/asyncapi.md
@@ -1003,7 +1003,7 @@ Field Name | Type | Description
 <a name="messageObjectTags"></a>tags | [Tags Object](#tagsObject) | A list of tags for API documentation control. Tags can be used for logical grouping of messages.
 <a name="messageObjectExternalDocs"></a>externalDocs | [External Documentation Object](#externalDocumentationObject) | Additional external documentation for this message.
 <a name="messageObjectBindings"></a>bindings | [Message Bindings Object](#messageBindingsObject) | A map where the keys describe the name of the protocol and the values describe protocol-specific definitions for the message.
-<a name="messageObjectExamples"></a>examples | [`any`] | An array with examples of valid message objects. Whatever "any" is, it MUST match the type defined on the payload. 
+<a name="messageObjectExamples"></a>examples | [Map[`string`, `any`]] | An array with examples of valid message objects.
 <a name="messageObjectTraits"></a>traits | [[Message Trait Object](#messageTraitObject) &#124; [Reference Object](#referenceObject)] | A list of traits to apply to the message object. Traits MUST be merged into the message object using the [JSON Merge Patch](https://tools.ietf.org/html/rfc7386) algorithm in the same order they are defined here. The resulting object MUST be a valid [Message Object](#messageObject).
 
 This object can be extended with [Specification Extensions](#specificationExtensions).
@@ -1168,7 +1168,7 @@ Field Name | Type | Description
 <a name="messageTraitObjectTags"></a>tags | [Tags Object](#tagsObject) | A list of tags for API documentation control. Tags can be used for logical grouping of messages.
 <a name="messageTraitObjectExternalDocs"></a>externalDocs | [External Documentation Object](#externalDocumentationObject) | Additional external documentation for this message.
 <a name="messageTraitObjectBindings"></a>bindings | [Message Bindings Object](#messageBindingsObject) | A map where the keys describe the name of the protocol and the values describe protocol-specific definitions for the message.
-<a name="messageTraitObjectExamples"></a>examples | [`any`] | An array with examples of valid message objects. Whatever "any" is, it MUST match the type defined on the payload. 
+<a name="messageTraitObjectExamples"></a>examples | [Map[`string`, `any`]] | An array with examples of valid message objects.
 
 This object can be extended with [Specification Extensions](#specificationExtensions).
 

--- a/versions/2.0.0/schema.json
+++ b/versions/2.0.0/schema.json
@@ -689,7 +689,9 @@
                 },
                 "examples": {
                   "type": "array",
-                  "items": {}
+                  "items": {
+                    "type": "object"
+                  }
                 },
                 "bindings": {
                   "$ref": "#/definitions/bindingsObject"
@@ -903,7 +905,9 @@
         },
         "examples": {
           "type": "array",
-          "items": {}
+          "items": {
+            "type": "object"
+          }
         },
         "bindings": {
           "$ref": "#/definitions/bindingsObject"


### PR DESCRIPTION
Reverts asyncapi/asyncapi#436

@BlockLucas Sorry man, I messed it up the other day. The spec was correct but unclear: https://github.com/asyncapi/html-template/issues/59#issuecomment-695999153.

We should still keep that `Whatever "any" is, it MUST match the type defined on the payload.` but slightly rephrased because it can be `headers` or `payload`. We should also make it clear that the "string" in "[Map[`string`, `any`]]" can actually only be either `headers` or `payload`.