### PR TITLE
fix: change minItems of oneOf and anyOf to 1

### DIFF
--- a/versions/2.0.0/schema.json
+++ b/versions/2.0.0/schema.json
@@ -399,14 +399,14 @@
             },
             "oneOf": {
               "type": "array",
-              "minItems": 2,
+              "minItems": 1,
               "items": {
                 "$ref": "#/definitions/schema"
               }
             },
             "anyOf": {
               "type": "array",
-              "minItems": 2,
+              "minItems": 1,
               "items": {
                 "$ref": "#/definitions/schema"
               }


### PR DESCRIPTION
**Description**
I briefly created a test action to test this change, but found there are some existing actions that just didn't run in my fork. I'm hoping that automated testing is performed when I open this PR. I don't have a Node environment setup so was intending to use CI to test.

<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow our contribution guidelines
2. Test your changes and attach their results to the pull request.
3. Update the relevant documentation.
-->

**Related issue(s)**
Resolves https://github.com/asyncapi/asyncapi/issues/492
<!-- If you refer to a particular issue, provide its number, othewise, remove this section.
For example, `Resolves #123`, `Fixes #43`, or `See also #33`. The `See also #33` option will not automatically close the issue after the PR merge. -->